### PR TITLE
Update treeherder REST url from project/{proj}/resultset/{push} to pr…

### DIFF
--- a/perfherder/perfherder.js
+++ b/perfherder/perfherder.js
@@ -14,7 +14,7 @@ function buildTreeHerderURL({ interval, signature, framework }) {
   return url;
 }
 async function getPushIdRevision(push_id, callback) {
-  let url = "https://treeherder.mozilla.org/api/project/mozilla-central/resultset/" + push_id + "/";
+  let url = "https://treeherder.mozilla.org/api/project/mozilla-central/push/" + push_id + "/";
   let { revision } = await fetchJSON(url);
   return revision;
 }


### PR DESCRIPTION
…oject/{proj}/push/{push}

There is another call to {proj}/resultset in inspect.js, but I have never used the /inspect section of the app and the URL looked weird so I didn't update it here.