### PR TITLE
Add debugger preview

### DIFF
--- a/perfherder/perfherder-signatures.js
+++ b/perfherder/perfherder-signatures.js
@@ -4,92 +4,43 @@ const PerfHerderSignatures = {
       "windows7-32-opt": {
         "signature": "2fa549258445b035f7463afad97852e46b399a6d",
         "id": 1760562,
-        "old_signatures": [
-          {
-            "signature": "2fa549258445b035f7463afad97852e46b399a6d",
-            "id": 1539640,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows7-32-pgo": {
         "signature": "389a5b1ef37772bad22611e4d6237fffea35c9cb",
         "id": 1761212,
-        "old_signatures": [
-          {
-            "signature": "389a5b1ef37772bad22611e4d6237fffea35c9cb",
-            "id": 1539018,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows10-64-opt": {
         "signature": "28c4fee1ef7d4e5d184aa628df7c94de208b7678",
         "id": 1760887,
-        "old_signatures": [
-          {
-            "signature": "28c4fee1ef7d4e5d184aa628df7c94de208b7678",
-            "id": 1538275,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows10-64-pgo": {
         "signature": "2e2b666b2c9746ca9fe1184efc6f182c330e8398",
         "id": 1761277,
-        "old_signatures": [
-          {
-            "signature": "2e2b666b2c9746ca9fe1184efc6f182c330e8398",
-            "id": 1539027,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "linux64-opt": {
         "signature": "f79b6a4f1f8f53326d3056f6c8008c0ff4de0a94",
         "id": 1760367,
-        "old_signatures": [
-          {
-            "signature": "f79b6a4f1f8f53326d3056f6c8008c0ff4de0a94",
-            "id": 1649531,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "linux64-pgo": {
         "signature": "d0aa31b4a8617d5bda9bc8c5ca7bfa9a77c38c7c",
         "id": 1761017,
-        "old_signatures": [
-          {
-            "signature": "d0aa31b4a8617d5bda9bc8c5ca7bfa9a77c38c7c",
-            "id": 1654448,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "osx-10-10-opt": {
         "signature": "7cbb05567f41ef34c669c6987c808f3fc1f5ef57",
         "id": 1760757,
-        "old_signatures": [
-          {
-            "signature": "7cbb05567f41ef34c669c6987c808f3fc1f5ef57",
-            "id": 1542635,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       }
     }
@@ -99,8630 +50,44 @@ const PerfHerderSignatures = {
       "windows7-32-opt": {
         "signature": "75892d40388be4c3ed0cacfd3809634c745c352a",
         "id": 1760563,
-        "old_signatures": [
-          {
-            "signature": "75892d40388be4c3ed0cacfd3809634c745c352a",
-            "id": 1654655,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows7-32-pgo": {
         "signature": "8897315c3f8ea0920a0e928144f2516251d788eb",
         "id": 1761213,
-        "old_signatures": [
-          {
-            "signature": "8897315c3f8ea0920a0e928144f2516251d788eb",
-            "id": 1655181,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows10-64-opt": {
         "signature": "7ff2b74e68cf3bb6de95e0ba41bc2ac3123292e5",
         "id": 1760888,
-        "old_signatures": [
-          {
-            "signature": "7ff2b74e68cf3bb6de95e0ba41bc2ac3123292e5",
-            "id": 1653980,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "windows10-64-pgo": {
         "signature": "aa90a824351b4f5bc019ad8bb1cc7ba82d724a7a",
         "id": 1761278,
-        "old_signatures": [
-          {
-            "signature": "aa90a824351b4f5bc019ad8bb1cc7ba82d724a7a",
-            "id": 1656347,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "linux64-opt": {
         "signature": "c3ac3ab674fc4852863176608fd2001c90e0526d",
         "id": 1760368,
-        "old_signatures": [
-          {
-            "signature": "c3ac3ab674fc4852863176608fd2001c90e0526d",
-            "id": 1649532,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "linux64-pgo": {
         "signature": "0d02b575b2ec61dc0dfb078d87699f25622d60ed",
         "id": 1761018,
-        "old_signatures": [
-          {
-            "signature": "0d02b575b2ec61dc0dfb078d87699f25622d60ed",
-            "id": 1654449,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
       },
       "osx-10-10-opt": {
         "signature": "0a182af619108c1dfad911cc05b05b37b65fd355",
         "id": 1760758,
-        "old_signatures": [
-          {
-            "signature": "0a182af619108c1dfad911cc05b05b37b65fd355",
-            "id": 1652253,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
+        "old_signatures": [],
         "framework": 12
-      }
-    }
-  },
-  "cold.inspector.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bb66a7c0faebade326dc8d50ed6e6919613b9fc9",
-            "id": 1654656,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c56c8bdcbe2cccc7eacb9700244ab3cab7af1572",
-            "id": 1655182,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "22fe80370d423f0133d7d606bc76d5091446564f",
-            "id": 1653981,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "479a281152473d813b24cabf76dda3b35cd915c5",
-            "id": 1656348,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e13582d0eddedd4e28e4f3109c19826604125432",
-            "id": 1649533,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "cca23c3d155afc375c4e463e12604bf482e63c93",
-            "id": 1654450,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c52fc1fde83812d8842b78a8f11761e90b4a1865",
-            "id": 1652254,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.inspector.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b7f624daa73e971e36152c16934cf9c4c9d4e8f5",
-        "id": 1760586,
-        "old_signatures": [
-          {
-            "signature": "b7f624daa73e971e36152c16934cf9c4c9d4e8f5",
-            "id": 1539671,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "1b0081a95becbc1bb66f146747c5bbd4947c65ba",
-        "id": 1761236,
-        "old_signatures": [
-          {
-            "signature": "1b0081a95becbc1bb66f146747c5bbd4947c65ba",
-            "id": 1539116,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "3409ce5a386eb37e4df1e0d7c7b348459197ddd5",
-        "id": 1760911,
-        "old_signatures": [
-          {
-            "signature": "3409ce5a386eb37e4df1e0d7c7b348459197ddd5",
-            "id": 1538306,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "ca6bd87c43503c3c9fa38e94acb5ecd3d114744e",
-        "id": 1761301,
-        "old_signatures": [
-          {
-            "signature": "ca6bd87c43503c3c9fa38e94acb5ecd3d114744e",
-            "id": 1539134,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "e6a72c92fb7f84b33b17e776756e08e6e0e8a8f9",
-        "id": 1760391,
-        "old_signatures": [
-          {
-            "signature": "e6a72c92fb7f84b33b17e776756e08e6e0e8a8f9",
-            "id": 1649582,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "d7424265f0f927b870db2c1ded29218999d248bb",
-        "id": 1761041,
-        "old_signatures": [
-          {
-            "signature": "d7424265f0f927b870db2c1ded29218999d248bb",
-            "id": 1654499,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "b6c6658b10a2ad447d7c6c0eb75e56f375c516ca",
-        "id": 1760781,
-        "old_signatures": [
-          {
-            "signature": "b6c6658b10a2ad447d7c6c0eb75e56f375c516ca",
-            "id": 1542666,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.inspector.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "2b910c2eeba6c8ddbd4ddeb3c46ab3e7bee5ad5f",
-        "id": 1760584,
-        "old_signatures": [
-          {
-            "signature": "2b910c2eeba6c8ddbd4ddeb3c46ab3e7bee5ad5f",
-            "id": 1539669,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "0da14803ccd551bd6c152a191ce46170451dab0f",
-        "id": 1761234,
-        "old_signatures": [
-          {
-            "signature": "0da14803ccd551bd6c152a191ce46170451dab0f",
-            "id": 1539106,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "007cb478c4c3686bc227d65bfe4fbf9e52c7e171",
-        "id": 1760909,
-        "old_signatures": [
-          {
-            "signature": "007cb478c4c3686bc227d65bfe4fbf9e52c7e171",
-            "id": 1538304,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "ea121aea77be73e88646daeeae7ac8ffd6e9a095",
-        "id": 1761299,
-        "old_signatures": [
-          {
-            "signature": "ea121aea77be73e88646daeeae7ac8ffd6e9a095",
-            "id": 1539128,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "db299ac114d1f5ff89b8c0a41b27bab19f4c0c51",
-        "id": 1760389,
-        "old_signatures": [
-          {
-            "signature": "db299ac114d1f5ff89b8c0a41b27bab19f4c0c51",
-            "id": 1649578,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "fb515ef3c8374463918c5947e9f91e4909aedcf8",
-        "id": 1761039,
-        "old_signatures": [
-          {
-            "signature": "fb515ef3c8374463918c5947e9f91e4909aedcf8",
-            "id": 1654495,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c95aa15a753d9fb128b37349932e73413349aed9",
-        "id": 1760779,
-        "old_signatures": [
-          {
-            "signature": "c95aa15a753d9fb128b37349932e73413349aed9",
-            "id": 1542664,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.inspector.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "be320c4b77a069921f000c58c60722d658232176",
-            "id": 1654673,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "d4aa9607edd5950677ccfb4464a2f344c6a8e9c3",
-            "id": 1655232,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "72d95929309cf67ef39a849ab76563c6c55733ab",
-            "id": 1653998,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "802968c61316abfd4107e13404edac84af2266ae",
-            "id": 1656365,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "34bba19d4c6298b682cda58a9f2f64b70dc010dc",
-            "id": 1649579,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bf7ca7cfdde0c9b6083e5d0a46ec7d85e16f82cf",
-            "id": 1654496,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f07044214a908665361bdfda968fe67cd7875432",
-            "id": 1652271,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.inspector.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "3d161f7ba7086b83675da84ca55ac19ba0bb9a58",
-        "id": 1760585,
-        "old_signatures": [
-          {
-            "signature": "3d161f7ba7086b83675da84ca55ac19ba0bb9a58",
-            "id": 1539670,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "4b1c7719ec651d0c5fa7be4cde11eb5ec324dd0e",
-        "id": 1761235,
-        "old_signatures": [
-          {
-            "signature": "4b1c7719ec651d0c5fa7be4cde11eb5ec324dd0e",
-            "id": 1539112,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "8dc367a5e5b15f482667853facac248a513b51f8",
-        "id": 1760910,
-        "old_signatures": [
-          {
-            "signature": "8dc367a5e5b15f482667853facac248a513b51f8",
-            "id": 1538305,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "93866d84946f2442755d82fe393743612e160c8c",
-        "id": 1761300,
-        "old_signatures": [
-          {
-            "signature": "93866d84946f2442755d82fe393743612e160c8c",
-            "id": 1539131,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "9438fe01afb26eab3d43bac8b09de5123d59ae2e",
-        "id": 1760390,
-        "old_signatures": [
-          {
-            "signature": "9438fe01afb26eab3d43bac8b09de5123d59ae2e",
-            "id": 1649580,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "b1bff4e07a610268bc01273c5c634d076527fee0",
-        "id": 1761040,
-        "old_signatures": [
-          {
-            "signature": "b1bff4e07a610268bc01273c5c634d076527fee0",
-            "id": 1654497,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "9bc5647bfce1a6f9f0603ecee39bdc77b125f611",
-        "id": 1760780,
-        "old_signatures": [
-          {
-            "signature": "9bc5647bfce1a6f9f0603ecee39bdc77b125f611",
-            "id": 1542665,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.inspector.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f398f4c30bc32c8908193766a669eccf90263de6",
-            "id": 1654674,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "63e7d91e76bb73dfa99d1ac2959e81890a23cac4",
-            "id": 1655235,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "8503c7474d08463034c727c2b5205c9366b1ba24",
-            "id": 1653999,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7026b7eab6c64302a6176da3a18784c920865605",
-            "id": 1656366,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "270c714aeaba322810166d9a4401c1bd59a6d20c",
-            "id": 1649581,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f0471460eccf6c23dafeabf8f6f810a048a8a035",
-            "id": 1654498,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f2025cc9565f5faa4eaf5165c8aaabc252308993",
-            "id": 1652272,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.jsdebugger.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "daa0684c9dc259a935cb0fb2ec879a4f8898aae2",
-        "id": 1760589,
-        "old_signatures": [
-          {
-            "signature": "daa0684c9dc259a935cb0fb2ec879a4f8898aae2",
-            "id": 1539674,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "fad7dd04d26a5384dd8660b10e6e74af7c278dbc",
-        "id": 1761239,
-        "old_signatures": [
-          {
-            "signature": "fad7dd04d26a5384dd8660b10e6e74af7c278dbc",
-            "id": 1539132,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4e1fa3dcac185e333633303660b28b886c3c054d",
-        "id": 1760914,
-        "old_signatures": [
-          {
-            "signature": "4e1fa3dcac185e333633303660b28b886c3c054d",
-            "id": 1538309,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "b7fbc150bf385a7532ffdd95dd87963900342ced",
-        "id": 1761304,
-        "old_signatures": [
-          {
-            "signature": "b7fbc150bf385a7532ffdd95dd87963900342ced",
-            "id": 1539145,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "01a48a65cc0406d65a648ca7777d755e3115eaee",
-        "id": 1760394,
-        "old_signatures": [
-          {
-            "signature": "01a48a65cc0406d65a648ca7777d755e3115eaee",
-            "id": 1649587,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "fbbc0c5aa54c10ad34fd47b6bfa90ee4eee52500",
-        "id": 1761044,
-        "old_signatures": [
-          {
-            "signature": "fbbc0c5aa54c10ad34fd47b6bfa90ee4eee52500",
-            "id": 1654504,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "ad98a19382269e4da1ec31ca4ab313e3d8785595",
-        "id": 1760784,
-        "old_signatures": [
-          {
-            "signature": "ad98a19382269e4da1ec31ca4ab313e3d8785595",
-            "id": 1542669,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.jsdebugger.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "feaa3690bbacca1448fee2af716615518a32f628",
-        "id": 1760587,
-        "old_signatures": [
-          {
-            "signature": "feaa3690bbacca1448fee2af716615518a32f628",
-            "id": 1539672,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "3da5755babcdbb89a4b8e3b2f4e6927e9d68abc1",
-        "id": 1761237,
-        "old_signatures": [
-          {
-            "signature": "3da5755babcdbb89a4b8e3b2f4e6927e9d68abc1",
-            "id": 1539122,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "99004e108af7dc62837f92ec9ea7c73dc0d172fc",
-        "id": 1760912,
-        "old_signatures": [
-          {
-            "signature": "99004e108af7dc62837f92ec9ea7c73dc0d172fc",
-            "id": 1538307,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "c3459d23df4a6655b3ec23e629eaf90af6302fcc",
-        "id": 1761302,
-        "old_signatures": [
-          {
-            "signature": "c3459d23df4a6655b3ec23e629eaf90af6302fcc",
-            "id": 1539138,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "3adac34e5e1fb79c06b80625920a9b0b76b12d5f",
-        "id": 1760392,
-        "old_signatures": [
-          {
-            "signature": "3adac34e5e1fb79c06b80625920a9b0b76b12d5f",
-            "id": 1649583,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "282645ae33d2d3025c06204da0dde0a936cd2b11",
-        "id": 1761042,
-        "old_signatures": [
-          {
-            "signature": "282645ae33d2d3025c06204da0dde0a936cd2b11",
-            "id": 1654500,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "b48cc63f6ecdf0af242d54cc055567aabbaf4fc0",
-        "id": 1760782,
-        "old_signatures": [
-          {
-            "signature": "b48cc63f6ecdf0af242d54cc055567aabbaf4fc0",
-            "id": 1542667,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.jsdebugger.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "11ef03aa286eb67957e822dc6c4117bc8036b309",
-            "id": 1654675,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "6eb10751f8def80030aa7ab79faa8af1a306d9b5",
-            "id": 1655238,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2d057d87dea1a45378d336c44b110cee4dd71a8b",
-            "id": 1654000,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0424f723fe2d8124d2aa1a2f4980862bb6fe9aef",
-            "id": 1656367,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1e47ef9559cf8ada3b39286a5e5c00372a38ae5a",
-            "id": 1649584,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "58590d024f0d36f89f8eabfdf7f779d6165297ed",
-            "id": 1654501,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "9a0d1381211d9c311b257263381118800f51777f",
-            "id": 1652273,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.jsdebugger.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "c928d511ba65453fd5427bdace953d6b9a455dec",
-        "id": 1760588,
-        "old_signatures": [
-          {
-            "signature": "c928d511ba65453fd5427bdace953d6b9a455dec",
-            "id": 1539673,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "e1fbd375db9555ead277540af902e0a91acffad5",
-        "id": 1761238,
-        "old_signatures": [
-          {
-            "signature": "e1fbd375db9555ead277540af902e0a91acffad5",
-            "id": 1539126,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "f9de681fc7f192f147299d9c36b61e41085b2f5b",
-        "id": 1760913,
-        "old_signatures": [
-          {
-            "signature": "f9de681fc7f192f147299d9c36b61e41085b2f5b",
-            "id": 1538308,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "5bbf597daa6eebc3c417df4e3529e53b3b715b8a",
-        "id": 1761303,
-        "old_signatures": [
-          {
-            "signature": "5bbf597daa6eebc3c417df4e3529e53b3b715b8a",
-            "id": 1539141,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "63194a9fb5bf2a19af5e45b9ba507e08a68157ed",
-        "id": 1760393,
-        "old_signatures": [
-          {
-            "signature": "63194a9fb5bf2a19af5e45b9ba507e08a68157ed",
-            "id": 1649585,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "9e325cc34e6de95e2408fbf36e3240d469b5cd93",
-        "id": 1761043,
-        "old_signatures": [
-          {
-            "signature": "9e325cc34e6de95e2408fbf36e3240d469b5cd93",
-            "id": 1654502,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "9e7dd5932b6f4680d34ec827ea4508b7df94fc4b",
-        "id": 1760783,
-        "old_signatures": [
-          {
-            "signature": "9e7dd5932b6f4680d34ec827ea4508b7df94fc4b",
-            "id": 1542668,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.jsdebugger.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "254afe588c8fdff7696fa3ed32ab4f955919f174",
-            "id": 1654676,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "4f550cb28e3728b9b6dc52f6dfcbf0fc5ef1bcb6",
-            "id": 1655241,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7baa2a5ab9bf6434fcba9f130aa4fc9320a37c1a",
-            "id": 1654001,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e972615c7cc5ade94cff7f139ec4b42cb2207391",
-            "id": 1656368,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "cb0e1e437396a79a6d01a2b5898ba30abc933154",
-            "id": 1649586,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "920cb95f1f800c255f568c61e2c485f3b724788d",
-            "id": 1654503,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "87590da6329c797715b14e7a01e45edeb5782cbd",
-            "id": 1652274,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.netmonitor.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b3059e47ab8fd79887bc7c69cd3bf17235afb5c6",
-        "id": 1760597,
-        "old_signatures": [
-          {
-            "signature": "b3059e47ab8fd79887bc7c69cd3bf17235afb5c6",
-            "id": 1539684,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "6fcda28e2fc6eeefb137a698aa319aa588b06a78",
-        "id": 1761247,
-        "old_signatures": [
-          {
-            "signature": "6fcda28e2fc6eeefb137a698aa319aa588b06a78",
-            "id": 1539178,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "0e641c9704f5cff8c8e823403483910650e6efe6",
-        "id": 1760922,
-        "old_signatures": [
-          {
-            "signature": "0e641c9704f5cff8c8e823403483910650e6efe6",
-            "id": 1538319,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "ffc1538363be9f7ab7b459c81221a0398d9ca1e3",
-        "id": 1761312,
-        "old_signatures": [
-          {
-            "signature": "ffc1538363be9f7ab7b459c81221a0398d9ca1e3",
-            "id": 1539186,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "2de1f58d829ebf59179090a590529409ead7d207",
-        "id": 1760402,
-        "old_signatures": [
-          {
-            "signature": "2de1f58d829ebf59179090a590529409ead7d207",
-            "id": 1649603,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "795fd01fba0a8de4df6fe8b006d6517fe3ef110f",
-        "id": 1761052,
-        "old_signatures": [
-          {
-            "signature": "795fd01fba0a8de4df6fe8b006d6517fe3ef110f",
-            "id": 1654520,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "f90859f08e2040b059a37c10d4bbfa0cc889aad0",
-        "id": 1760792,
-        "old_signatures": [
-          {
-            "signature": "f90859f08e2040b059a37c10d4bbfa0cc889aad0",
-            "id": 1542679,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.netmonitor.exportHar": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "6108a397d3aeedb9cd2260732e8d22708aceabdc",
-        "id": 1760596,
-        "old_signatures": [
-          {
-            "signature": "6108a397d3aeedb9cd2260732e8d22708aceabdc",
-            "id": 1668812,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "f686d5f33068063f5fb0cc33ffbed7f5974294d1",
-        "id": 1761246,
-        "old_signatures": [
-          {
-            "signature": "f686d5f33068063f5fb0cc33ffbed7f5974294d1",
-            "id": 1668815,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "ade33e40355950b8cb1501e74555e7800394b6c8",
-        "id": 1760921,
-        "old_signatures": [
-          {
-            "signature": "ade33e40355950b8cb1501e74555e7800394b6c8",
-            "id": 1668810,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "3a11fb6aff0d978fdd048c40d99eb51ff92ad020",
-        "id": 1761311,
-        "old_signatures": [
-          {
-            "signature": "3a11fb6aff0d978fdd048c40d99eb51ff92ad020",
-            "id": 1668816,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "935faaf13b5c5cd9b78b4851804320eea67dbc1b",
-        "id": 1760401,
-        "old_signatures": [
-          {
-            "signature": "935faaf13b5c5cd9b78b4851804320eea67dbc1b",
-            "id": 1668800,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "43c7c7dcf3662fa575c4639c97e1cdd64ee7ac88",
-        "id": 1761051,
-        "old_signatures": [
-          {
-            "signature": "43c7c7dcf3662fa575c4639c97e1cdd64ee7ac88",
-            "id": 1668804,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "6a45c0ffb341d2649f724a0771b6b1308acc8825",
-        "id": 1760791,
-        "old_signatures": [
-          {
-            "signature": "6a45c0ffb341d2649f724a0771b6b1308acc8825",
-            "id": 1668806,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.netmonitor.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "54aef1de540fcbc1d588991683b0b4550a5b003b",
-        "id": 1760593,
-        "old_signatures": [
-          {
-            "signature": "54aef1de540fcbc1d588991683b0b4550a5b003b",
-            "id": 1539681,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "56cfd90fe8470a1df759766a08567a58005a8c1a",
-        "id": 1761243,
-        "old_signatures": [
-          {
-            "signature": "56cfd90fe8470a1df759766a08567a58005a8c1a",
-            "id": 1539166,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "45d66273b901685c84a2e4c143e686edcc7a8fb5",
-        "id": 1760918,
-        "old_signatures": [
-          {
-            "signature": "45d66273b901685c84a2e4c143e686edcc7a8fb5",
-            "id": 1538316,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "94c7c1744c6d3b44b54e929ed60545cd6e884549",
-        "id": 1761308,
-        "old_signatures": [
-          {
-            "signature": "94c7c1744c6d3b44b54e929ed60545cd6e884549",
-            "id": 1539173,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "a829d97a075d511bbbca238ad36f420b46bc6c2c",
-        "id": 1760398,
-        "old_signatures": [
-          {
-            "signature": "a829d97a075d511bbbca238ad36f420b46bc6c2c",
-            "id": 1649598,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "7c6d23ab92b551a20f01418f0ec0658d6b169695",
-        "id": 1761048,
-        "old_signatures": [
-          {
-            "signature": "7c6d23ab92b551a20f01418f0ec0658d6b169695",
-            "id": 1654515,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c2ebc4e5ed81535c7c5adca2afcb0f96eea3ca72",
-        "id": 1760788,
-        "old_signatures": [
-          {
-            "signature": "c2ebc4e5ed81535c7c5adca2afcb0f96eea3ca72",
-            "id": 1542676,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.netmonitor.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "6541705dedc48aedb5b70e9b6d0e87dd1cff07a7",
-            "id": 1654681,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "b9366e27037f908efb1f04f988cfa88207cc3621",
-            "id": 1655255,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a9d79d9279de975d84cd5b9a556a0233694bb1e1",
-            "id": 1654006,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "6f03fbe8486ee4de872830de953d9e3fe901d507",
-            "id": 1656373,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "14fcb04424980520100dd0df665762bdb60e994a",
-            "id": 1649599,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "babb3ecb76fad1b9c17445dbf7d42d1387bf2d65",
-            "id": 1654516,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "fb6d1511d194f1989cbbcf07f6b0906ed1cdf838",
-            "id": 1652279,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.netmonitor.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "1ae6d0ccab36d3d95cefbf345bc2d6c7667835a7",
-        "id": 1760594,
-        "old_signatures": [
-          {
-            "signature": "1ae6d0ccab36d3d95cefbf345bc2d6c7667835a7",
-            "id": 1539682,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "e2b668d9216d94f76b2800f07caefcee78b88ee4",
-        "id": 1761244,
-        "old_signatures": [
-          {
-            "signature": "e2b668d9216d94f76b2800f07caefcee78b88ee4",
-            "id": 1539170,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4f5054ef4194c2fe8af14e7cdb8947f6bc9dd6bb",
-        "id": 1760919,
-        "old_signatures": [
-          {
-            "signature": "4f5054ef4194c2fe8af14e7cdb8947f6bc9dd6bb",
-            "id": 1538317,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "344218eb5d4cc56c25813cae0c5411f2f961e0ee",
-        "id": 1761309,
-        "old_signatures": [
-          {
-            "signature": "344218eb5d4cc56c25813cae0c5411f2f961e0ee",
-            "id": 1539177,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "adcab331a70cfd234d0b42c06687c3ea96cd0535",
-        "id": 1760399,
-        "old_signatures": [
-          {
-            "signature": "adcab331a70cfd234d0b42c06687c3ea96cd0535",
-            "id": 1649600,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "4ef53cf4e3a6b2677ec4c23bf100dd7aaf996b7a",
-        "id": 1761049,
-        "old_signatures": [
-          {
-            "signature": "4ef53cf4e3a6b2677ec4c23bf100dd7aaf996b7a",
-            "id": 1654517,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "913fee75317c4b51c8ad09cb36f8dcadb5adaf75",
-        "id": 1760789,
-        "old_signatures": [
-          {
-            "signature": "913fee75317c4b51c8ad09cb36f8dcadb5adaf75",
-            "id": 1542677,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.netmonitor.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ebc4d97095b52d859e237937f1eeab70ac439b84",
-            "id": 1654682,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "92a98d127458fb61c890ff1d8e803067eed53619",
-            "id": 1655258,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "b759b183218e188b7c04a51c315d2f40c2bff3ae",
-            "id": 1654007,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "cb1cc330b30450c819d19048d675f925a9850629",
-            "id": 1656374,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "13a16102f76aed238e7282e5a2c41e7b54a29ca8",
-            "id": 1649601,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3dc4530049356d2b85454bccf0c7f9ba47810748",
-            "id": 1654518,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f64fed39deacbb9e63b2e6029fb1f4b19e8924ea",
-            "id": 1652280,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.netmonitor.requestsFinished": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "4277c12f4a9a1b16c59d56d61ee18e760a7c0d6b",
-        "id": 1760595,
-        "old_signatures": [
-          {
-            "signature": "4277c12f4a9a1b16c59d56d61ee18e760a7c0d6b",
-            "id": 1539683,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "f4fb2079504ff5935e7c19609bd4efa77d99221e",
-        "id": 1761245,
-        "old_signatures": [
-          {
-            "signature": "f4fb2079504ff5935e7c19609bd4efa77d99221e",
-            "id": 1539174,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "c0593c68649271014f173674fc2721942a1882db",
-        "id": 1760920,
-        "old_signatures": [
-          {
-            "signature": "c0593c68649271014f173674fc2721942a1882db",
-            "id": 1538318,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "60afeb088b4b853812011e69e4422b8e3cbffe12",
-        "id": 1761310,
-        "old_signatures": [
-          {
-            "signature": "60afeb088b4b853812011e69e4422b8e3cbffe12",
-            "id": 1539181,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "c5ed310296444acb3515536648fab1812527b3d1",
-        "id": 1760400,
-        "old_signatures": [
-          {
-            "signature": "c5ed310296444acb3515536648fab1812527b3d1",
-            "id": 1649602,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "74948c0737bdf76aa962e057b47f47feede8996c",
-        "id": 1761050,
-        "old_signatures": [
-          {
-            "signature": "74948c0737bdf76aa962e057b47f47feede8996c",
-            "id": 1654519,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "b6a2299f76b7f147830900315ab82b9f71581784",
-        "id": 1760790,
-        "old_signatures": [
-          {
-            "signature": "b6a2299f76b7f147830900315ab82b9f71581784",
-            "id": 1542678,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.styleeditor.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "556abd694c808840ae9e139396cb8faa4d85da35",
-        "id": 1760592,
-        "old_signatures": [
-          {
-            "signature": "556abd694c808840ae9e139396cb8faa4d85da35",
-            "id": 1539677,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "ea0dc95ba0d22990f19a669b0287befe96c8e341",
-        "id": 1761242,
-        "old_signatures": [
-          {
-            "signature": "ea0dc95ba0d22990f19a669b0287befe96c8e341",
-            "id": 1539147,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "88271215eac1271235cd6d7bfcb0ac37a6008cf1",
-        "id": 1760917,
-        "old_signatures": [
-          {
-            "signature": "88271215eac1271235cd6d7bfcb0ac37a6008cf1",
-            "id": 1538312,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "51d4895ecf1e6ab11ef40c8bcdc697b2e5502fa2",
-        "id": 1761307,
-        "old_signatures": [
-          {
-            "signature": "51d4895ecf1e6ab11ef40c8bcdc697b2e5502fa2",
-            "id": 1539156,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "ef9a07d9fe64dd94dd7a57a094d329defcb8a7e8",
-        "id": 1760397,
-        "old_signatures": [
-          {
-            "signature": "ef9a07d9fe64dd94dd7a57a094d329defcb8a7e8",
-            "id": 1649592,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "99f50ab4f7ca3144644c518bab47c8aaeceee9ed",
-        "id": 1761047,
-        "old_signatures": [
-          {
-            "signature": "99f50ab4f7ca3144644c518bab47c8aaeceee9ed",
-            "id": 1654509,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "d06c0f2feb7169bee79607f37405f265bf051f2e",
-        "id": 1760787,
-        "old_signatures": [
-          {
-            "signature": "d06c0f2feb7169bee79607f37405f265bf051f2e",
-            "id": 1542672,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.styleeditor.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "08d23f93ae105fe023935ec9c42ff5775da72ba3",
-        "id": 1760590,
-        "old_signatures": [
-          {
-            "signature": "08d23f93ae105fe023935ec9c42ff5775da72ba3",
-            "id": 1539675,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "63eba2b7086049839895afe37296622e633bc687",
-        "id": 1761240,
-        "old_signatures": [
-          {
-            "signature": "63eba2b7086049839895afe37296622e633bc687",
-            "id": 1539137,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "119a69488b336b468d438927c62549b895ef1e7c",
-        "id": 1760915,
-        "old_signatures": [
-          {
-            "signature": "119a69488b336b468d438927c62549b895ef1e7c",
-            "id": 1538310,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "92d4e7132ccbe1f6156fb77f62aef81406f43c17",
-        "id": 1761305,
-        "old_signatures": [
-          {
-            "signature": "92d4e7132ccbe1f6156fb77f62aef81406f43c17",
-            "id": 1539149,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "73d5c526dd4deb10d7e3bd01508703e75a17850b",
-        "id": 1760395,
-        "old_signatures": [
-          {
-            "signature": "73d5c526dd4deb10d7e3bd01508703e75a17850b",
-            "id": 1649588,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "0fb7c78277878642e9f016bf00dfc5ac64e6bcd7",
-        "id": 1761045,
-        "old_signatures": [
-          {
-            "signature": "0fb7c78277878642e9f016bf00dfc5ac64e6bcd7",
-            "id": 1654505,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "39c057c5a3a4779146e0a99d145575b5180300df",
-        "id": 1760785,
-        "old_signatures": [
-          {
-            "signature": "39c057c5a3a4779146e0a99d145575b5180300df",
-            "id": 1542670,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.styleeditor.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "83fa37a633cfd52fb3e53046f0f13e4dbf953d99",
-            "id": 1654677,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "260bce2eb8ca56bbfa65aa270b582c76d7ebeff6",
-            "id": 1655244,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "21f727deac0b97742f657b2391b73f75d7841165",
-            "id": 1654002,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3457419a17c6cef165dfc45d412be00cff3feba3",
-            "id": 1656369,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "deb11ad5aa7227e74a969735c235d99061f6019d",
-            "id": 1649589,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f3434ee70305d4b7b8bdcbcf6acec3f985e78b82",
-            "id": 1654506,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "daccf806188edb03320b0f2fa9595669f4b09a18",
-            "id": 1652275,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.styleeditor.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "da1678e53b92f62297e2a48beddf7afadafbfd77",
-        "id": 1760591,
-        "old_signatures": [
-          {
-            "signature": "da1678e53b92f62297e2a48beddf7afadafbfd77",
-            "id": 1539676,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "fa5dc71bbb9b12c7c49dc192d0a597cdc079d649",
-        "id": 1761241,
-        "old_signatures": [
-          {
-            "signature": "fa5dc71bbb9b12c7c49dc192d0a597cdc079d649",
-            "id": 1539142,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "6816252593fa4ded443d58651b243a27981d4204",
-        "id": 1760916,
-        "old_signatures": [
-          {
-            "signature": "6816252593fa4ded443d58651b243a27981d4204",
-            "id": 1538311,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "a68a94b0548bfc0d329889fb0fe3f6294c5fbeab",
-        "id": 1761306,
-        "old_signatures": [
-          {
-            "signature": "a68a94b0548bfc0d329889fb0fe3f6294c5fbeab",
-            "id": 1539152,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "b8b69e494f9886b00ff98143ef0fd62f25248a84",
-        "id": 1760396,
-        "old_signatures": [
-          {
-            "signature": "b8b69e494f9886b00ff98143ef0fd62f25248a84",
-            "id": 1649590,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "eaca97f9a79609ee2a6b0a87aa0cfaccf20f1618",
-        "id": 1761046,
-        "old_signatures": [
-          {
-            "signature": "eaca97f9a79609ee2a6b0a87aa0cfaccf20f1618",
-            "id": 1654507,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "1f91027f887f3e4fc65d3388bb89d883ca3f1cd2",
-        "id": 1760786,
-        "old_signatures": [
-          {
-            "signature": "1f91027f887f3e4fc65d3388bb89d883ca3f1cd2",
-            "id": 1542671,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.styleeditor.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "02e33cff5f4e54b774311fabdcd67613758bcb2a",
-            "id": 1654678,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c2214045b2013865b9d085b33edf81dd33c0766b",
-            "id": 1655247,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "01e1b8187ae7649cebb9c5c8176152c7c8ee81ed",
-            "id": 1654003,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "043da44402181c95f59b7d422125e2ffe1513d58",
-            "id": 1656370,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3251d684f341c28f4c9f487e192531b13291d60d",
-            "id": 1649591,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "48764f8c8724960b995e758214edac0bfc328200",
-            "id": 1654508,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a513b3f8da9edb5d74ca15ded2f77c68a468f1ae",
-            "id": 1652276,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.webconsole.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "376d56fce6598fc6e9f06a7acfa9198a2aece31f",
-        "id": 1760583,
-        "old_signatures": [
-          {
-            "signature": "376d56fce6598fc6e9f06a7acfa9198a2aece31f",
-            "id": 1539668,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "c4729dea54b9a8d313d5209d86536b0be1a447f3",
-        "id": 1761233,
-        "old_signatures": [
-          {
-            "signature": "c4729dea54b9a8d313d5209d86536b0be1a447f3",
-            "id": 1539102,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "188d859463f5d658bd1448ac8ccca0e9006c8aa2",
-        "id": 1760908,
-        "old_signatures": [
-          {
-            "signature": "188d859463f5d658bd1448ac8ccca0e9006c8aa2",
-            "id": 1538303,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "659dddf77d66fadc854aec301b8b8c1ad92ac49e",
-        "id": 1761298,
-        "old_signatures": [
-          {
-            "signature": "659dddf77d66fadc854aec301b8b8c1ad92ac49e",
-            "id": 1539125,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "9b0bbf2ea023e080cdfd9a77e0915d2d46293b83",
-        "id": 1760388,
-        "old_signatures": [
-          {
-            "signature": "9b0bbf2ea023e080cdfd9a77e0915d2d46293b83",
-            "id": 1649577,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "a519a7395bc93e5c29f3cd8b8e939f0a45dfd06c",
-        "id": 1761038,
-        "old_signatures": [
-          {
-            "signature": "a519a7395bc93e5c29f3cd8b8e939f0a45dfd06c",
-            "id": 1654494,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "35fb1261bd1162fa1594a0a0ff80af4e81cc3027",
-        "id": 1760778,
-        "old_signatures": [
-          {
-            "signature": "35fb1261bd1162fa1594a0a0ff80af4e81cc3027",
-            "id": 1542663,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.webconsole.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "7e4f9bc41206489c4ea9ea0bc58bd58a51f93074",
-        "id": 1760581,
-        "old_signatures": [
-          {
-            "signature": "7e4f9bc41206489c4ea9ea0bc58bd58a51f93074",
-            "id": 1539666,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "ef31076b53aa9114d461b861dba6e1b1c40efe00",
-        "id": 1761231,
-        "old_signatures": [
-          {
-            "signature": "ef31076b53aa9114d461b861dba6e1b1c40efe00",
-            "id": 1539087,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "419bec5cb54e2b8081594dae3e5ff6c0b9d61309",
-        "id": 1760906,
-        "old_signatures": [
-          {
-            "signature": "419bec5cb54e2b8081594dae3e5ff6c0b9d61309",
-            "id": 1538301,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "3adabb863066d79a923ab27f5545c039ba8b15a0",
-        "id": 1761296,
-        "old_signatures": [
-          {
-            "signature": "3adabb863066d79a923ab27f5545c039ba8b15a0",
-            "id": 1539119,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "5e273b93875f10482d4ab2f6f31a3398d769bb6d",
-        "id": 1760386,
-        "old_signatures": [
-          {
-            "signature": "5e273b93875f10482d4ab2f6f31a3398d769bb6d",
-            "id": 1649573,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "6599f8b6a38145c116337212286197946ea38fcf",
-        "id": 1761036,
-        "old_signatures": [
-          {
-            "signature": "6599f8b6a38145c116337212286197946ea38fcf",
-            "id": 1654490,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "d64e2ac7edf41b832db83e9978470786ef8a834b",
-        "id": 1760776,
-        "old_signatures": [
-          {
-            "signature": "d64e2ac7edf41b832db83e9978470786ef8a834b",
-            "id": 1542661,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.webconsole.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c99a6b5b9d293b8a3561be0b1a7ac8f2c20a92fc",
-            "id": 1654671,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3df8bde8525d2bc41d5a1043193287cb746fb4ee",
-            "id": 1655227,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "b851a50a9ceb0283c9b6b65ea9d7c29f03a00255",
-            "id": 1653996,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "38349b87288c9e4e8ddaf393caf36481f4254991",
-            "id": 1656363,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "9c400893dc7271067584cac4f14f39f0000121bf",
-            "id": 1649574,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "32f06e1a8f378f12e2413bc8654f7144da0bd711",
-            "id": 1654491,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0c1444e10a954832eccf8330e0da1ba45f3e7f3e",
-            "id": 1652269,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "complicated.webconsole.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "0fbc038982a367696566c8e5fa09ce6b72003e9f",
-        "id": 1760582,
-        "old_signatures": [
-          {
-            "signature": "0fbc038982a367696566c8e5fa09ce6b72003e9f",
-            "id": 1539667,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "776b9c360d720ecd93c583d3468daa1ce7989f16",
-        "id": 1761232,
-        "old_signatures": [
-          {
-            "signature": "776b9c360d720ecd93c583d3468daa1ce7989f16",
-            "id": 1539095,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "88d15829227ecea9ffaca6fd7ad287e23beb9dda",
-        "id": 1760907,
-        "old_signatures": [
-          {
-            "signature": "88d15829227ecea9ffaca6fd7ad287e23beb9dda",
-            "id": 1538302,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "73b1cce2a5c278319a366c327d84ea19af80843e",
-        "id": 1761297,
-        "old_signatures": [
-          {
-            "signature": "73b1cce2a5c278319a366c327d84ea19af80843e",
-            "id": 1539121,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "ad373754e919e41067b2f4788b2ff9b0d88dd86f",
-        "id": 1760387,
-        "old_signatures": [
-          {
-            "signature": "ad373754e919e41067b2f4788b2ff9b0d88dd86f",
-            "id": 1649575,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "06632a464fcae8eeafa6246c834acd84c43d851b",
-        "id": 1761037,
-        "old_signatures": [
-          {
-            "signature": "06632a464fcae8eeafa6246c834acd84c43d851b",
-            "id": 1654492,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "9e5f2685e8ffee8585f96fd93bfc5111f5c22cdf",
-        "id": 1760777,
-        "old_signatures": [
-          {
-            "signature": "9e5f2685e8ffee8585f96fd93bfc5111f5c22cdf",
-            "id": 1542662,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "complicated.webconsole.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "26b890778abe7caaf99eecfae36779c82deb9c23",
-            "id": 1654672,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e90cc4acdadd07439c8cf6d2fbd6133945575f46",
-            "id": 1655229,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ffd0dcbe9b2c15a06dd0e06c73332097b57868fb",
-            "id": 1653997,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "221368d0dc68ad09a9cd9633b2a38b04ac30c39c",
-            "id": 1656364,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1cd168a5656172546af674c6755438fec5d54aa5",
-            "id": 1649576,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3be460eb6163ed9cca09610524b1e5c25e57e66f",
-            "id": 1654493,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "59eb063b457d6cc0a8b514ded6af35704bbecc18",
-            "id": 1652270,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "console.autocomplete": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "e25e10aeeec007ac780c230a2503988c34347a4e",
-        "id": 1760618,
-        "old_signatures": [
-          {
-            "signature": "e25e10aeeec007ac780c230a2503988c34347a4e",
-            "id": 1730033,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "feff187641eb21701861bcbd5896e504029914a5",
-        "id": 1761268,
-        "old_signatures": [
-          {
-            "signature": "feff187641eb21701861bcbd5896e504029914a5",
-            "id": 1730042,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "8479c9c0c7054c78a7977aaddabc4a4f63b026e5",
-        "id": 1760943,
-        "old_signatures": [
-          {
-            "signature": "8479c9c0c7054c78a7977aaddabc4a4f63b026e5",
-            "id": 1730034,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "f61e942f0ce7d1906da19543bcc3ddded327e761",
-        "id": 1761333,
-        "old_signatures": [
-          {
-            "signature": "f61e942f0ce7d1906da19543bcc3ddded327e761",
-            "id": 1730039,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "0278f6f740f18a96b43d0baeace4ffb0a35f064e",
-        "id": 1760423,
-        "old_signatures": [
-          {
-            "signature": "0278f6f740f18a96b43d0baeace4ffb0a35f064e",
-            "id": 1730031,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "00fd75c22fa18b7ff3b54a69dbdb3fbebb1b17c9",
-        "id": 1761073,
-        "old_signatures": [
-          {
-            "signature": "00fd75c22fa18b7ff3b54a69dbdb3fbebb1b17c9",
-            "id": 1730036,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "de3f444654c8a1f83d20df9ad9f685bf6492d546",
-        "id": 1760813,
-        "old_signatures": [
-          {
-            "signature": "de3f444654c8a1f83d20df9ad9f685bf6492d546",
-            "id": 1730038,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "console.bulklog": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "db81a5d13d30568d5c15765aecff7001ac7c88a1",
-        "id": 1760617,
-        "old_signatures": [
-          {
-            "signature": "db81a5d13d30568d5c15765aecff7001ac7c88a1",
-            "id": 1539691,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "3ebe094bf174dde78108535acf57399a3ecee0df",
-        "id": 1761267,
-        "old_signatures": [
-          {
-            "signature": "3ebe094bf174dde78108535acf57399a3ecee0df",
-            "id": 1539207,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "300288dc3bbe95c671cc51108a8bcb360768589b",
-        "id": 1760942,
-        "old_signatures": [
-          {
-            "signature": "300288dc3bbe95c671cc51108a8bcb360768589b",
-            "id": 1538326,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "c443da532210865d5902853a62a2649ab1735ab7",
-        "id": 1761332,
-        "old_signatures": [
-          {
-            "signature": "c443da532210865d5902853a62a2649ab1735ab7",
-            "id": 1539217,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "e5a0446f5f248c6490695dd2d90ec608175957c9",
-        "id": 1760422,
-        "old_signatures": [
-          {
-            "signature": "e5a0446f5f248c6490695dd2d90ec608175957c9",
-            "id": 1649627,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "6758cecba0cf4d2b048648ee657f5c541c3c157c",
-        "id": 1761072,
-        "old_signatures": [
-          {
-            "signature": "6758cecba0cf4d2b048648ee657f5c541c3c157c",
-            "id": 1654544,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "96f15af34024a9373cec4cc03a6aaf8a00ed8ad2",
-        "id": 1760812,
-        "old_signatures": [
-          {
-            "signature": "96f15af34024a9373cec4cc03a6aaf8a00ed8ad2",
-            "id": 1542686,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "console.objectexpand": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "cecba81df61dff9fda652dbb1a77326e507cfcd5",
-        "id": 1760620,
-        "old_signatures": [
-          {
-            "signature": "cecba81df61dff9fda652dbb1a77326e507cfcd5",
-            "id": 1654700,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "4ee3029bb70e429a064e7788c8b845b1a116248f",
-        "id": 1761270,
-        "old_signatures": [
-          {
-            "signature": "4ee3029bb70e429a064e7788c8b845b1a116248f",
-            "id": 1655297,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "28c867a96d2e41cb3428c096f569e9d2089391df",
-        "id": 1760945,
-        "old_signatures": [
-          {
-            "signature": "28c867a96d2e41cb3428c096f569e9d2089391df",
-            "id": 1654025,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "eca3c7266d17aaaab1f00de6b0fb70438fd4f4f6",
-        "id": 1761335,
-        "old_signatures": [
-          {
-            "signature": "eca3c7266d17aaaab1f00de6b0fb70438fd4f4f6",
-            "id": 1656392,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "31f7776cd76a6058f6dbf380be3dcecf650a8c0b",
-        "id": 1760425,
-        "old_signatures": [
-          {
-            "signature": "31f7776cd76a6058f6dbf380be3dcecf650a8c0b",
-            "id": 1649629,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "a1a748e1c38d2a9d01c07091fe5a2f59ee4f30c0",
-        "id": 1761075,
-        "old_signatures": [
-          {
-            "signature": "a1a748e1c38d2a9d01c07091fe5a2f59ee4f30c0",
-            "id": 1654546,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "9febe43c04703458dfcbd7df1d22ff25900b3798",
-        "id": 1760815,
-        "old_signatures": [
-          {
-            "signature": "9febe43c04703458dfcbd7df1d22ff25900b3798",
-            "id": 1652298,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "console.objectexpanded.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "bc1cf0fe5ecf781af339b2739ed483e3a3be3d80",
-        "id": 1760621,
-        "old_signatures": [
-          {
-            "signature": "bc1cf0fe5ecf781af339b2739ed483e3a3be3d80",
-            "id": 1654701,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "570e06c012b8ffe1c7fc217357972cd9ce28c277",
-        "id": 1761271,
-        "old_signatures": [
-          {
-            "signature": "570e06c012b8ffe1c7fc217357972cd9ce28c277",
-            "id": 1655299,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "aaefd257d5e25ef88fe06867cc2a0084f2cbbc10",
-        "id": 1760946,
-        "old_signatures": [
-          {
-            "signature": "aaefd257d5e25ef88fe06867cc2a0084f2cbbc10",
-            "id": 1654026,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "df33420e6f9ea5e82ae6b7dd640c9acba5d52f1c",
-        "id": 1761336,
-        "old_signatures": [
-          {
-            "signature": "df33420e6f9ea5e82ae6b7dd640c9acba5d52f1c",
-            "id": 1656393,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "b0e8f4dcb75883dffceee221f35c044274d3c624",
-        "id": 1760426,
-        "old_signatures": [
-          {
-            "signature": "b0e8f4dcb75883dffceee221f35c044274d3c624",
-            "id": 1649630,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "6d413bcc545817d29d997e573ab5be08edd85080",
-        "id": 1761076,
-        "old_signatures": [
-          {
-            "signature": "6d413bcc545817d29d997e573ab5be08edd85080",
-            "id": 1654547,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "38712d8025e02f8a319f84a7218b5596d21ebbe9",
-        "id": 1760816,
-        "old_signatures": [
-          {
-            "signature": "38712d8025e02f8a319f84a7218b5596d21ebbe9",
-            "id": 1652299,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "console.openwithcache.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b8bd7706560ae232ac2bc18fcc7b27750e59da42",
-        "id": 1760622,
-        "old_signatures": [
-          {
-            "signature": "b8bd7706560ae232ac2bc18fcc7b27750e59da42",
-            "id": 1654702,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "ffd1f0a82b5923c5dbecd61313eb7e82b520b345",
-        "id": 1761272,
-        "old_signatures": [
-          {
-            "signature": "ffd1f0a82b5923c5dbecd61313eb7e82b520b345",
-            "id": 1655301,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "1ed55698ceaaea75966410c0fbbd3c67f6cc13d4",
-        "id": 1760947,
-        "old_signatures": [
-          {
-            "signature": "1ed55698ceaaea75966410c0fbbd3c67f6cc13d4",
-            "id": 1654027,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "0ea965fe139ba245e3b01c69047cb741d4f6115d",
-        "id": 1761337,
-        "old_signatures": [
-          {
-            "signature": "0ea965fe139ba245e3b01c69047cb741d4f6115d",
-            "id": 1656394,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "b12966be150fb8d180683c9994b95b7b41717d8b",
-        "id": 1760427,
-        "old_signatures": [
-          {
-            "signature": "b12966be150fb8d180683c9994b95b7b41717d8b",
-            "id": 1649631,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "864fbb1e6873ac43507c0cf27e75bf752600bcbe",
-        "id": 1761077,
-        "old_signatures": [
-          {
-            "signature": "864fbb1e6873ac43507c0cf27e75bf752600bcbe",
-            "id": 1654548,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "5fe65e2ffc0a9119dbe0e917cf8d1a7d8609fcb7",
-        "id": 1760817,
-        "old_signatures": [
-          {
-            "signature": "5fe65e2ffc0a9119dbe0e917cf8d1a7d8609fcb7",
-            "id": 1652300,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "console.openwithcache.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "6b752fa3131e1fd458ff43e257579880120294b4",
-            "id": 1654703,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3e8369c934d2282e13a82151d0d5be03e83690bd",
-            "id": 1655303,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2816e18771050bdc813a8ea95fb6c6ee668b24a3",
-            "id": 1654028,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "456c7b714a9ae5f69035b56971ffa3eb11ea5569",
-            "id": 1656395,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "5dd2d8904f356b7bbd0dccf7e32dd840f3e8aea0",
-            "id": 1649632,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0f1065304230195196c57fe2ae9e89685afb8711",
-            "id": 1654549,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "92dad87b599bf047e55bb9296bb66568acf7e643",
-            "id": 1652301,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "console.streamlog": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "ac8ed43934946b4dbe8c04e69c09a3faf0a7c868",
-        "id": 1760619,
-        "old_signatures": [
-          {
-            "signature": "ac8ed43934946b4dbe8c04e69c09a3faf0a7c868",
-            "id": 1539692,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a4f43672d6a58f09e58e5767061132d84291ca81",
-        "id": 1761269,
-        "old_signatures": [
-          {
-            "signature": "a4f43672d6a58f09e58e5767061132d84291ca81",
-            "id": 1539212,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "0afec0b8791193fb419a58b0e405f26f4e756606",
-        "id": 1760944,
-        "old_signatures": [
-          {
-            "signature": "0afec0b8791193fb419a58b0e405f26f4e756606",
-            "id": 1538327,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "8125a25776bba26d29a6ce0867605667e9d62a97",
-        "id": 1761334,
-        "old_signatures": [
-          {
-            "signature": "8125a25776bba26d29a6ce0867605667e9d62a97",
-            "id": 1539222,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "95ca6e2f4bb93a07e52f3b5daa236570578e3e3a",
-        "id": 1760424,
-        "old_signatures": [
-          {
-            "signature": "95ca6e2f4bb93a07e52f3b5daa236570578e3e3a",
-            "id": 1649628,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "10beb945872afdd821b499d58d7f9209ca60bb4b",
-        "id": 1761074,
-        "old_signatures": [
-          {
-            "signature": "10beb945872afdd821b499d58d7f9209ca60bb4b",
-            "id": 1654545,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "fd76c8c981e076287bcbcdf1f96809f16287c022",
-        "id": 1760814,
-        "old_signatures": [
-          {
-            "signature": "fd76c8c981e076287bcbcdf1f96809f16287c022",
-            "id": 1542687,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "60ec776cdbe6fe307bf5b5136e42a3014b4b2d81",
-        "id": 1760609,
-        "old_signatures": [
-          {
-            "signature": "60ec776cdbe6fe307bf5b5136e42a3014b4b2d81",
-            "id": 1654694,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a3b490795c60c181414c32bb4f1e6b86855ce7bb",
-        "id": 1761259,
-        "old_signatures": [
-          {
-            "signature": "a3b490795c60c181414c32bb4f1e6b86855ce7bb",
-            "id": 1655283,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "538d15e12e16c4cd1da35450962508ae2e6a505c",
-        "id": 1760934,
-        "old_signatures": [
-          {
-            "signature": "538d15e12e16c4cd1da35450962508ae2e6a505c",
-            "id": 1654019,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "9c2ee0821b08fd5880aaa681bc06ea079ea823e0",
-        "id": 1761324,
-        "old_signatures": [
-          {
-            "signature": "9c2ee0821b08fd5880aaa681bc06ea079ea823e0",
-            "id": 1656386,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "ed44b53b68761edace9fc54831c6b3b2e99da789",
-        "id": 1760414,
-        "old_signatures": [
-          {
-            "signature": "ed44b53b68761edace9fc54831c6b3b2e99da789",
-            "id": 1649621,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "17a82fb0c17f471ea24b26ee68c3673cccffefcd",
-        "id": 1761064,
-        "old_signatures": [
-          {
-            "signature": "17a82fb0c17f471ea24b26ee68c3673cccffefcd",
-            "id": 1654538,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "f26b405b7a4eb657aeb031830eeb4b7b53228355",
-        "id": 1760804,
-        "old_signatures": [
-          {
-            "signature": "f26b405b7a4eb657aeb031830eeb4b7b53228355",
-            "id": 1652292,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.collapseall.balanced": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b57d746f0ca2222590ab1930e2dbef650e08c4d2",
-        "id": 1760608,
-        "old_signatures": [
-          {
-            "signature": "b57d746f0ca2222590ab1930e2dbef650e08c4d2",
-            "id": 1669250,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "12955855421820c74bcfca3d964fdb277a5786dc",
-        "id": 1761258,
-        "old_signatures": [
-          {
-            "signature": "12955855421820c74bcfca3d964fdb277a5786dc",
-            "id": 1669266,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "89cca895530ffffe586c13a357364de764a5cf2d",
-        "id": 1760933,
-        "old_signatures": [
-          {
-            "signature": "89cca895530ffffe586c13a357364de764a5cf2d",
-            "id": 1669246,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "2e6f1a4585f22f6f166375c3e1a30cb06c2647ea",
-        "id": 1761323,
-        "old_signatures": [
-          {
-            "signature": "2e6f1a4585f22f6f166375c3e1a30cb06c2647ea",
-            "id": 1669262,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "e4e2177920f02792673589b094f5ed7b1f535a96",
-        "id": 1760413,
-        "old_signatures": [
-          {
-            "signature": "e4e2177920f02792673589b094f5ed7b1f535a96",
-            "id": 1669219,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "18dedca3c3f19d8eb61403aabd4229d491efa002",
-        "id": 1761063,
-        "old_signatures": [
-          {
-            "signature": "18dedca3c3f19d8eb61403aabd4229d491efa002",
-            "id": 1669233,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "a51d40db8d43b1975d39e1e608f1fd6bb21957fc",
-        "id": 1760803,
-        "old_signatures": [
-          {
-            "signature": "a51d40db8d43b1975d39e1e608f1fd6bb21957fc",
-            "id": 1669237,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.collapseall.manychildren": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "d0ecc7f767e58731a00f4ea594770eb3c64fdb3d",
-        "id": 1760606,
-        "old_signatures": [
-          {
-            "signature": "d0ecc7f767e58731a00f4ea594770eb3c64fdb3d",
-            "id": 1669248,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "f39c53ac6a2c256c4bc46449ba604a68731342fe",
-        "id": 1761256,
-        "old_signatures": [
-          {
-            "signature": "f39c53ac6a2c256c4bc46449ba604a68731342fe",
-            "id": 1669264,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4d10c7a48800e10204915618036273f2eff2d2d7",
-        "id": 1760931,
-        "old_signatures": [
-          {
-            "signature": "4d10c7a48800e10204915618036273f2eff2d2d7",
-            "id": 1669244,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "5e79d623284e3da9927c7d7cd9606db289db7c83",
-        "id": 1761321,
-        "old_signatures": [
-          {
-            "signature": "5e79d623284e3da9927c7d7cd9606db289db7c83",
-            "id": 1669260,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "62e13ef684cef1c52c89cc41c5da390c763aa653",
-        "id": 1760411,
-        "old_signatures": [
-          {
-            "signature": "62e13ef684cef1c52c89cc41c5da390c763aa653",
-            "id": 1669217,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "69a9919c36605c29cd235284e7871318322e265b",
-        "id": 1761061,
-        "old_signatures": [
-          {
-            "signature": "69a9919c36605c29cd235284e7871318322e265b",
-            "id": 1669231,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "47a0e46ce8f85d7dd972fd591206d25c603081d7",
-        "id": 1760801,
-        "old_signatures": [
-          {
-            "signature": "47a0e46ce8f85d7dd972fd591206d25c603081d7",
-            "id": 1669235,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.expandall.balanced": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "ead7726d0d2b0e35baa721a2ff8252a053d483f5",
-        "id": 1760607,
-        "old_signatures": [
-          {
-            "signature": "ead7726d0d2b0e35baa721a2ff8252a053d483f5",
-            "id": 1669249,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "973b5d4e5868961b43bec0d6533eddd9ed9b3afa",
-        "id": 1761257,
-        "old_signatures": [
-          {
-            "signature": "973b5d4e5868961b43bec0d6533eddd9ed9b3afa",
-            "id": 1669265,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "59da1c07433f9e90767db6a3be601d86c3f30fd4",
-        "id": 1760932,
-        "old_signatures": [
-          {
-            "signature": "59da1c07433f9e90767db6a3be601d86c3f30fd4",
-            "id": 1669245,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "f7815d0d0f49ae2680d4ea6b1e7062362185a3cc",
-        "id": 1761322,
-        "old_signatures": [
-          {
-            "signature": "f7815d0d0f49ae2680d4ea6b1e7062362185a3cc",
-            "id": 1669261,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "071c79a5c33da0e3147318bc69a60eaaa9d1aaff",
-        "id": 1760412,
-        "old_signatures": [
-          {
-            "signature": "071c79a5c33da0e3147318bc69a60eaaa9d1aaff",
-            "id": 1669218,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "a36450bf9e4fcd440681d7641f845836ff2d4dad",
-        "id": 1761062,
-        "old_signatures": [
-          {
-            "signature": "a36450bf9e4fcd440681d7641f845836ff2d4dad",
-            "id": 1669232,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "7b6601f7e21f7c63f5f44267c029bb19fcae7c63",
-        "id": 1760802,
-        "old_signatures": [
-          {
-            "signature": "7b6601f7e21f7c63f5f44267c029bb19fcae7c63",
-            "id": 1669236,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.expandall.manychildren": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "c0f0a0819480c48a5c16fe16d4744d34b8a7e068",
-        "id": 1760605,
-        "old_signatures": [
-          {
-            "signature": "c0f0a0819480c48a5c16fe16d4744d34b8a7e068",
-            "id": 1669247,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "03ab439d3b745f3bf5145f9c79ff68b27ff94ee3",
-        "id": 1761255,
-        "old_signatures": [
-          {
-            "signature": "03ab439d3b745f3bf5145f9c79ff68b27ff94ee3",
-            "id": 1669263,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "80ad355f369824cfa9b238cbce39ec335a733980",
-        "id": 1760930,
-        "old_signatures": [
-          {
-            "signature": "80ad355f369824cfa9b238cbce39ec335a733980",
-            "id": 1669243,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "b790b56a44d75201ae23ebd8c044207be8ec326e",
-        "id": 1761320,
-        "old_signatures": [
-          {
-            "signature": "b790b56a44d75201ae23ebd8c044207be8ec326e",
-            "id": 1669259,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "2827dd590756caff04628f65c6f15710fce569c7",
-        "id": 1760410,
-        "old_signatures": [
-          {
-            "signature": "2827dd590756caff04628f65c6f15710fce569c7",
-            "id": 1669216,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "41b372283739b2fc36406400f7fe01d9aa86377e",
-        "id": 1761060,
-        "old_signatures": [
-          {
-            "signature": "41b372283739b2fc36406400f7fe01d9aa86377e",
-            "id": 1669230,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "4c8d1e397c97df7847e5eaa2305b4f664d6eca17",
-        "id": 1760800,
-        "old_signatures": [
-          {
-            "signature": "4c8d1e397c97df7847e5eaa2305b4f664d6eca17",
-            "id": 1669234,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.manyrules.deselectnode": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "5df2100b57dbfb3fe591e68edac693a80845c431",
-        "id": 1760604,
-        "old_signatures": [
-          {
-            "signature": "5df2100b57dbfb3fe591e68edac693a80845c431",
-            "id": 1663659,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "5ec9abef734d3a539837567a4d2e875d7b7af25b",
-        "id": 1761254,
-        "old_signatures": [
-          {
-            "signature": "5ec9abef734d3a539837567a4d2e875d7b7af25b",
-            "id": 1663683,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4b1126b5bc0b70d6dcd065b8b27350c6ab94001c",
-        "id": 1760929,
-        "old_signatures": [
-          {
-            "signature": "4b1126b5bc0b70d6dcd065b8b27350c6ab94001c",
-            "id": 1663625,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "2e08d27fc847fffe3930e1f32d0a2fab77baa660",
-        "id": 1761319,
-        "old_signatures": [
-          {
-            "signature": "2e08d27fc847fffe3930e1f32d0a2fab77baa660",
-            "id": 1663691,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "308a29c813bc4f09b131fffcd0c6d1d1f55b5470",
-        "id": 1760409,
-        "old_signatures": [
-          {
-            "signature": "308a29c813bc4f09b131fffcd0c6d1d1f55b5470",
-            "id": 1663503,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "2517f1804caaa7aaffce8534231c537dfeb04035",
-        "id": 1761059,
-        "old_signatures": [
-          {
-            "signature": "2517f1804caaa7aaffce8534231c537dfeb04035",
-            "id": 1663615,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "97513decb49751b7d81c8a94fc3e6fdb78a6b448",
-        "id": 1760799,
-        "old_signatures": [
-          {
-            "signature": "97513decb49751b7d81c8a94fc3e6fdb78a6b448",
-            "id": 1663617,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.manyrules.selectnode": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b0a24944b2d6c29c2af9d75223c3d6cb0dc49df1",
-        "id": 1760603,
-        "old_signatures": [
-          {
-            "signature": "b0a24944b2d6c29c2af9d75223c3d6cb0dc49df1",
-            "id": 1663658,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "c5378363a40f025761ee5ac41230c2bd3e297de7",
-        "id": 1761253,
-        "old_signatures": [
-          {
-            "signature": "c5378363a40f025761ee5ac41230c2bd3e297de7",
-            "id": 1663682,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "d02c62355f6fc106ac79ed925355c14cdc7ca519",
-        "id": 1760928,
-        "old_signatures": [
-          {
-            "signature": "d02c62355f6fc106ac79ed925355c14cdc7ca519",
-            "id": 1663624,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "68613286e9e4ca5056945dc77854c09404522c7f",
-        "id": 1761318,
-        "old_signatures": [
-          {
-            "signature": "68613286e9e4ca5056945dc77854c09404522c7f",
-            "id": 1663690,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "e461295da6e3d4a6fa60edf4fb0204d3dba0d84f",
-        "id": 1760408,
-        "old_signatures": [
-          {
-            "signature": "e461295da6e3d4a6fa60edf4fb0204d3dba0d84f",
-            "id": 1663502,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "cfd2d45ccfc1d43d4373cb1f47ad8b0f51542d30",
-        "id": 1761058,
-        "old_signatures": [
-          {
-            "signature": "cfd2d45ccfc1d43d4373cb1f47ad8b0f51542d30",
-            "id": 1663614,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "639c7b7bbe1683b63c3cbb6267a1e2e6dfe9a661",
-        "id": 1760798,
-        "old_signatures": [
-          {
-            "signature": "639c7b7bbe1683b63c3cbb6267a1e2e6dfe9a661",
-            "id": 1663616,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "a092ecfa6abb9137e7f3e77fdffb83df74161a22",
-        "id": 1760601,
-        "old_signatures": [
-          {
-            "signature": "a092ecfa6abb9137e7f3e77fdffb83df74161a22",
-            "id": 1654690,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "e2ec96e182ce4a171399761578a7a573ffcdec53",
-        "id": 1761251,
-        "old_signatures": [
-          {
-            "signature": "e2ec96e182ce4a171399761578a7a573ffcdec53",
-            "id": 1655275,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "c6ac5b2ac017145f39af01cf9f5b6008aae3bd60",
-        "id": 1760926,
-        "old_signatures": [
-          {
-            "signature": "c6ac5b2ac017145f39af01cf9f5b6008aae3bd60",
-            "id": 1654015,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "5e8338139d7426ca57a1ee813b896612c79e1c56",
-        "id": 1761316,
-        "old_signatures": [
-          {
-            "signature": "5e8338139d7426ca57a1ee813b896612c79e1c56",
-            "id": 1656382,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "7dc6817d8889e93e5281bd863517e28d9a56e6fb",
-        "id": 1760406,
-        "old_signatures": [
-          {
-            "signature": "7dc6817d8889e93e5281bd863517e28d9a56e6fb",
-            "id": 1649617,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "a8b03818ef1c4b1982fe113a82293360b7028c34",
-        "id": 1761056,
-        "old_signatures": [
-          {
-            "signature": "a8b03818ef1c4b1982fe113a82293360b7028c34",
-            "id": 1654534,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "71d1a05de4ef30977ed9dd55f8e46d4dc4afc9a6",
-        "id": 1760796,
-        "old_signatures": [
-          {
-            "signature": "71d1a05de4ef30977ed9dd55f8e46d4dc4afc9a6",
-            "id": 1652288,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "fdcc76333df8031ac7e69c1380346217cd98277d",
-            "id": 1654691,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "90815665453744d9da033fa027c768aa68cb46fa",
-            "id": 1655277,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0ade5d811caa426ca3eb3fb2ef4351c419add103",
-            "id": 1654016,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "176632a53321dbce83bad4a957eb875092ad1f97",
-            "id": 1656383,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2405906057c0c9f95215d0dd4576b94e98154982",
-            "id": 1649618,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e23495cb11732414dde9fcca590f37e42ca92a16",
-            "id": 1654535,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ec06af48da325b92fd9c4fccc7fd0e7cc259e398",
-            "id": 1652289,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "custom.inspector.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "0ea7359bbdc51abe74ee6fb06c80e93ee99fc479",
-        "id": 1760602,
-        "old_signatures": [
-          {
-            "signature": "0ea7359bbdc51abe74ee6fb06c80e93ee99fc479",
-            "id": 1654692,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "5814dfd8e08d6243515b396b1423a398e5c04e02",
-        "id": 1761252,
-        "old_signatures": [
-          {
-            "signature": "5814dfd8e08d6243515b396b1423a398e5c04e02",
-            "id": 1655279,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4dbcf10f692214140d6afd10bc8722b3bb93e7bf",
-        "id": 1760927,
-        "old_signatures": [
-          {
-            "signature": "4dbcf10f692214140d6afd10bc8722b3bb93e7bf",
-            "id": 1654017,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "e2be806f19e2b909d2f19f831be886d778b0c2d3",
-        "id": 1761317,
-        "old_signatures": [
-          {
-            "signature": "e2be806f19e2b909d2f19f831be886d778b0c2d3",
-            "id": 1656384,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "a27dbdaed8b47209a1f1d2e8f42b6a794dde29d7",
-        "id": 1760407,
-        "old_signatures": [
-          {
-            "signature": "a27dbdaed8b47209a1f1d2e8f42b6a794dde29d7",
-            "id": 1649619,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "6faa35709ca9fff83216ad70671b459aed2ec31b",
-        "id": 1761057,
-        "old_signatures": [
-          {
-            "signature": "6faa35709ca9fff83216ad70671b459aed2ec31b",
-            "id": 1654536,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "31f6e406245c03b97f99c86fd3533afbfa888b84",
-        "id": 1760797,
-        "old_signatures": [
-          {
-            "signature": "31f6e406245c03b97f99c86fd3533afbfa888b84",
-            "id": 1652290,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.inspector.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c4be0def0af03c0d9e96b7a341293f9374fe6687",
-            "id": 1654693,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "409abb1d8e0b3e53029198fa7a6a57d41bcda1a3",
-            "id": 1655281,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1844496be46a55aa369a800758e9cbbe02fe59e9",
-            "id": 1654018,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "67c373f96b60e76756549e3bb5d53d6ba68b23db",
-            "id": 1656385,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ef2cd6966c4bf482d8abc546853a47ca973a6a9b",
-            "id": 1649620,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "9477e63ba1aa176268bd2927ac093d6b39d243f7",
-            "id": 1654537,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "268a8715a3ea88f366f27ba9c6d41125af731bbc",
-            "id": 1652291,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "custom.jsdebugger.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "03d3b1f26439a1f4a0168c8539949f7d958dd036",
-        "id": 1760616,
-        "old_signatures": [
-          {
-            "signature": "03d3b1f26439a1f4a0168c8539949f7d958dd036",
-            "id": 1654699,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "7c13ffa2159b37f37d7706207bda2c021fede32d",
-        "id": 1761266,
-        "old_signatures": [
-          {
-            "signature": "7c13ffa2159b37f37d7706207bda2c021fede32d",
-            "id": 1655293,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "657faba36123fae63791830fe9800a9cf7e5a6da",
-        "id": 1760941,
-        "old_signatures": [
-          {
-            "signature": "657faba36123fae63791830fe9800a9cf7e5a6da",
-            "id": 1654024,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "f6753eaede93185719f89deff2a2ee6c204260ef",
-        "id": 1761331,
-        "old_signatures": [
-          {
-            "signature": "f6753eaede93185719f89deff2a2ee6c204260ef",
-            "id": 1656391,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "2a1c95b7ff355ebcd18141cb6ac26f6307fdf99d",
-        "id": 1760421,
-        "old_signatures": [
-          {
-            "signature": "2a1c95b7ff355ebcd18141cb6ac26f6307fdf99d",
-            "id": 1649626,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "10ccff7b55a48330a284d85766c0cb11e927ce4e",
-        "id": 1761071,
-        "old_signatures": [
-          {
-            "signature": "10ccff7b55a48330a284d85766c0cb11e927ce4e",
-            "id": 1654543,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c8691e770ccef615f796f5009ae64d103d69ba60",
-        "id": 1760811,
-        "old_signatures": [
-          {
-            "signature": "c8691e770ccef615f796f5009ae64d103d69ba60",
-            "id": 1652297,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "29cb6ad3bd290c5217c7935ac48af40d7835d38c",
-        "id": 1760610,
-        "old_signatures": [
-          {
-            "signature": "29cb6ad3bd290c5217c7935ac48af40d7835d38c",
-            "id": 1654695,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a9866b78c24f53b108dc0c51b471f01a2b4083df",
-        "id": 1761260,
-        "old_signatures": [
-          {
-            "signature": "a9866b78c24f53b108dc0c51b471f01a2b4083df",
-            "id": 1655285,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "8451f14751ff89f9bfd4dae7390dab99088bd3d3",
-        "id": 1760935,
-        "old_signatures": [
-          {
-            "signature": "8451f14751ff89f9bfd4dae7390dab99088bd3d3",
-            "id": 1654020,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "55981f370d210fa549f9befaf8100a77ece9d2fc",
-        "id": 1761325,
-        "old_signatures": [
-          {
-            "signature": "55981f370d210fa549f9befaf8100a77ece9d2fc",
-            "id": 1656387,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "942e6714fc1a5624cc063d7d13f60414f813c7d7",
-        "id": 1760415,
-        "old_signatures": [
-          {
-            "signature": "942e6714fc1a5624cc063d7d13f60414f813c7d7",
-            "id": 1649622,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "d8327d95e558a79bc1a61b3764ca25ae6ad7930a",
-        "id": 1761065,
-        "old_signatures": [
-          {
-            "signature": "d8327d95e558a79bc1a61b3764ca25ae6ad7930a",
-            "id": 1654539,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "af243d74450bfd10967613c35a1245b76ea259a0",
-        "id": 1760805,
-        "old_signatures": [
-          {
-            "signature": "af243d74450bfd10967613c35a1245b76ea259a0",
-            "id": 1652293,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3101cbbc20ee0b08fc3101bbaffef677224df28c",
-            "id": 1654696,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "deafcca3332eb82126626362659592f25d0a6085",
-            "id": 1655287,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "deb2514cb702ffe54b3cffedd52a35f55320ce6c",
-            "id": 1654021,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "61ae2e11cadc67287058b9353f91af2c81662949",
-            "id": 1656388,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "caae5527e6410941153021adec6784192e65b633",
-            "id": 1649623,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "79a9f43279388a9de0087f5d2f8d58a3b6740ae0",
-            "id": 1654540,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e8bcd90f652457c46400573326a76108b0c66c2f",
-            "id": 1652294,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "custom.jsdebugger.pause": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "e48a906ff2548551b585549bed8e40be1cda3e74",
-        "id": 1760612,
-        "old_signatures": [
-          {
-            "signature": "e48a906ff2548551b585549bed8e40be1cda3e74",
-            "id": 1668694,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a27a8f62b9e2cf72655922425ff202c7a96f5bab",
-        "id": 1761262,
-        "old_signatures": [
-          {
-            "signature": "a27a8f62b9e2cf72655922425ff202c7a96f5bab",
-            "id": 1668698,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "d70b820ddf74cdd6a200fcdc629f0af14235a092",
-        "id": 1760937,
-        "old_signatures": [
-          {
-            "signature": "d70b820ddf74cdd6a200fcdc629f0af14235a092",
-            "id": 1668690,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "0f33e5e8645bf85eeb33095125a608545b777e9d",
-        "id": 1761327,
-        "old_signatures": [
-          {
-            "signature": "0f33e5e8645bf85eeb33095125a608545b777e9d",
-            "id": 1668702,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "13ba4fa720daf00b66320cf315715dba2e53b429",
-        "id": 1760417,
-        "old_signatures": [
-          {
-            "signature": "13ba4fa720daf00b66320cf315715dba2e53b429",
-            "id": 1668674,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "24c7ab697210e88a75a042ef83ac1f3715d53671",
-        "id": 1761067,
-        "old_signatures": [
-          {
-            "signature": "24c7ab697210e88a75a042ef83ac1f3715d53671",
-            "id": 1668682,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "6d3c8f80d852a331471c4d1190d8680e5712909b",
-        "id": 1760807,
-        "old_signatures": [
-          {
-            "signature": "6d3c8f80d852a331471c4d1190d8680e5712909b",
-            "id": 1668686,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "fb540659f1d9a7756497e3a0d065f94cb8df5dd9",
-        "id": 1760611,
-        "old_signatures": [
-          {
-            "signature": "fb540659f1d9a7756497e3a0d065f94cb8df5dd9",
-            "id": 1654697,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "0a447de6a33dcf44fe3a2f591cf5c068fb385c9f",
-        "id": 1761261,
-        "old_signatures": [
-          {
-            "signature": "0a447de6a33dcf44fe3a2f591cf5c068fb385c9f",
-            "id": 1655288,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "6aa96350c4283bbf6bee1c07e7e883bedf692d2b",
-        "id": 1760936,
-        "old_signatures": [
-          {
-            "signature": "6aa96350c4283bbf6bee1c07e7e883bedf692d2b",
-            "id": 1654022,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "11a8d22b76fe9e1b9183e99a3d7c65d01f25f6dc",
-        "id": 1761326,
-        "old_signatures": [
-          {
-            "signature": "11a8d22b76fe9e1b9183e99a3d7c65d01f25f6dc",
-            "id": 1656389,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "f1b40e9f78c8b76b92848f248c77f49b5869b9c4",
-        "id": 1760416,
-        "old_signatures": [
-          {
-            "signature": "f1b40e9f78c8b76b92848f248c77f49b5869b9c4",
-            "id": 1649624,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "bd75fee9d559b0a31f8831b2a505ff39f61cd11d",
-        "id": 1761066,
-        "old_signatures": [
-          {
-            "signature": "bd75fee9d559b0a31f8831b2a505ff39f61cd11d",
-            "id": 1654541,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "7b75275679060c11bfce7d545736bd56bc5e07f9",
-        "id": 1760806,
-        "old_signatures": [
-          {
-            "signature": "7b75275679060c11bfce7d545736bd56bc5e07f9",
-            "id": 1652295,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f4d34a34492d2101243d1826626ccd7fac087c73",
-            "id": 1654698,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f0d011f08ff146ddc5fcca6c398ab6f7dc4933d4",
-            "id": 1655291,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3440733c8cbb6e86d84ee00140a7e516aa175089",
-            "id": 1654023,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "eb953d5bea8c09ecef1c9e95684541cdbda115ab",
-            "id": 1656390,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "78b5c3215b813e2372dcb684ba8c68a17cc9f289",
-            "id": 1649625,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1063e3f550c9ec9513f8ee9ff93b1eb5e79dda12",
-            "id": 1654542,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "5cb0e5b2214b88d92d02611dcce397e142954f89",
-            "id": 1652296,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "custom.jsdebugger.stepIn": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "f92b95e4f9362de27534dc069cd5db59ea5561e7",
-        "id": 1760613,
-        "old_signatures": [
-          {
-            "signature": "f92b95e4f9362de27534dc069cd5db59ea5561e7",
-            "id": 1668695,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "11329565da785675a2f801d7379959835c04c2ee",
-        "id": 1761263,
-        "old_signatures": [
-          {
-            "signature": "11329565da785675a2f801d7379959835c04c2ee",
-            "id": 1668699,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "81e530ca2fd10dbca8344a759bc9c86dfcb2ca6a",
-        "id": 1760938,
-        "old_signatures": [
-          {
-            "signature": "81e530ca2fd10dbca8344a759bc9c86dfcb2ca6a",
-            "id": 1668691,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "5c6560dc4a0854b862f5921b811e4bae50028807",
-        "id": 1761328,
-        "old_signatures": [
-          {
-            "signature": "5c6560dc4a0854b862f5921b811e4bae50028807",
-            "id": 1668703,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "6f37c3ba3eb01e234e2dbc9c3d02544346d083cd",
-        "id": 1760418,
-        "old_signatures": [
-          {
-            "signature": "6f37c3ba3eb01e234e2dbc9c3d02544346d083cd",
-            "id": 1668675,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "e5beaac2183892fd1032edaddecc71296e0c7f39",
-        "id": 1761068,
-        "old_signatures": [
-          {
-            "signature": "e5beaac2183892fd1032edaddecc71296e0c7f39",
-            "id": 1668683,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "d5370df8b258789dbb58bfe87c2878ad676c21ff",
-        "id": 1760808,
-        "old_signatures": [
-          {
-            "signature": "d5370df8b258789dbb58bfe87c2878ad676c21ff",
-            "id": 1668687,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.stepOut": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "6cab0854e637644aad510bd009dad1f44a0244ba",
-        "id": 1760615,
-        "old_signatures": [
-          {
-            "signature": "6cab0854e637644aad510bd009dad1f44a0244ba",
-            "id": 1668697,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "aa7cd73e3e6e7527778b70be16d01068a288028b",
-        "id": 1761265,
-        "old_signatures": [
-          {
-            "signature": "aa7cd73e3e6e7527778b70be16d01068a288028b",
-            "id": 1668701,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "0a7e16345804a32104c54b3cd9fa4b65b6397d11",
-        "id": 1760940,
-        "old_signatures": [
-          {
-            "signature": "0a7e16345804a32104c54b3cd9fa4b65b6397d11",
-            "id": 1668693,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "b4c86ea9a56f0c5350075c7bb348fdb8b39474f3",
-        "id": 1761330,
-        "old_signatures": [
-          {
-            "signature": "b4c86ea9a56f0c5350075c7bb348fdb8b39474f3",
-            "id": 1668705,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "9c53e48144fe27b59dfe5796879988bab7bb0d26",
-        "id": 1760420,
-        "old_signatures": [
-          {
-            "signature": "9c53e48144fe27b59dfe5796879988bab7bb0d26",
-            "id": 1668677,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "543a46b650daf6bc46b0c58c2e69e7170717a636",
-        "id": 1761070,
-        "old_signatures": [
-          {
-            "signature": "543a46b650daf6bc46b0c58c2e69e7170717a636",
-            "id": 1668685,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "10f7fe3fa3236851ca5f3df6cbedd7a3d2b63336",
-        "id": 1760810,
-        "old_signatures": [
-          {
-            "signature": "10f7fe3fa3236851ca5f3df6cbedd7a3d2b63336",
-            "id": 1668689,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.jsdebugger.stepOver": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "c9dec1559d576adadd067d0038e278084e65fb74",
-        "id": 1760614,
-        "old_signatures": [
-          {
-            "signature": "c9dec1559d576adadd067d0038e278084e65fb74",
-            "id": 1668696,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "500de38f0c32164d135236482e55e592bdfd2933",
-        "id": 1761264,
-        "old_signatures": [
-          {
-            "signature": "500de38f0c32164d135236482e55e592bdfd2933",
-            "id": 1668700,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "9e471ecaf4c4bf72ef3d2a5d76a1c41989372f72",
-        "id": 1760939,
-        "old_signatures": [
-          {
-            "signature": "9e471ecaf4c4bf72ef3d2a5d76a1c41989372f72",
-            "id": 1668692,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "be6b5f6c5813bc302d541ff3ae6a81c7bfd1b4a1",
-        "id": 1761329,
-        "old_signatures": [
-          {
-            "signature": "be6b5f6c5813bc302d541ff3ae6a81c7bfd1b4a1",
-            "id": 1668704,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "cfed29cc140fd4f23bcfb20a15644fee011e3ad3",
-        "id": 1760419,
-        "old_signatures": [
-          {
-            "signature": "cfed29cc140fd4f23bcfb20a15644fee011e3ad3",
-            "id": 1668676,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "2240cbe0958e108060710feb082d072a890c1ab4",
-        "id": 1761069,
-        "old_signatures": [
-          {
-            "signature": "2240cbe0958e108060710feb082d072a890c1ab4",
-            "id": 1668684,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "469af9d987e60ae6abee4cb583c6e1ad543db1ae",
-        "id": 1760809,
-        "old_signatures": [
-          {
-            "signature": "469af9d987e60ae6abee4cb583c6e1ad543db1ae",
-            "id": 1668688,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.webconsole.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "de570931bda5b3f2fc7daf9b4ce6baf8cf00dbbc",
-        "id": 1760600,
-        "old_signatures": [
-          {
-            "signature": "de570931bda5b3f2fc7daf9b4ce6baf8cf00dbbc",
-            "id": 1654689,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "bf7767e55ad2c96fcffb2cb3fbcc58abf284282f",
-        "id": 1761250,
-        "old_signatures": [
-          {
-            "signature": "bf7767e55ad2c96fcffb2cb3fbcc58abf284282f",
-            "id": 1655273,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "1eed0c74db9de1ac9b02c3a9c71109158d38e0af",
-        "id": 1760925,
-        "old_signatures": [
-          {
-            "signature": "1eed0c74db9de1ac9b02c3a9c71109158d38e0af",
-            "id": 1654014,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "d4faea71c810d023f69f2ed3b2cb2b132750c97b",
-        "id": 1761315,
-        "old_signatures": [
-          {
-            "signature": "d4faea71c810d023f69f2ed3b2cb2b132750c97b",
-            "id": 1656381,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "f93a80d8632e2d8ef36c011edf4f38a9b66af0d4",
-        "id": 1760405,
-        "old_signatures": [
-          {
-            "signature": "f93a80d8632e2d8ef36c011edf4f38a9b66af0d4",
-            "id": 1649616,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "8f98334178a5ca3c8f912f0178b45b0ef78deae0",
-        "id": 1761055,
-        "old_signatures": [
-          {
-            "signature": "8f98334178a5ca3c8f912f0178b45b0ef78deae0",
-            "id": 1654533,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "2499e81e179a1cc4fde187fcd6af64679258ded7",
-        "id": 1760795,
-        "old_signatures": [
-          {
-            "signature": "2499e81e179a1cc4fde187fcd6af64679258ded7",
-            "id": 1652287,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.webconsole.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "5a41c8b243fe8ec5b6d20a3239167cb57070539b",
-        "id": 1760598,
-        "old_signatures": [
-          {
-            "signature": "5a41c8b243fe8ec5b6d20a3239167cb57070539b",
-            "id": 1654685,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "6c82dd9af436c0e8c674c4df6bdff7740924e1ee",
-        "id": 1761248,
-        "old_signatures": [
-          {
-            "signature": "6c82dd9af436c0e8c674c4df6bdff7740924e1ee",
-            "id": 1655266,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "7f0a05c1f3274a0624709a3c49a010c170ecd9fb",
-        "id": 1760923,
-        "old_signatures": [
-          {
-            "signature": "7f0a05c1f3274a0624709a3c49a010c170ecd9fb",
-            "id": 1654010,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "2b63cffbb426fe8e554e7c921df57c76fe78c25e",
-        "id": 1761313,
-        "old_signatures": [
-          {
-            "signature": "2b63cffbb426fe8e554e7c921df57c76fe78c25e",
-            "id": 1656377,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "99a80e257b1cf8839c630f5250f4d4ac74d4d59f",
-        "id": 1760403,
-        "old_signatures": [
-          {
-            "signature": "99a80e257b1cf8839c630f5250f4d4ac74d4d59f",
-            "id": 1649612,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "5a84815bd324703c235b20c58e8f9eb1471e4046",
-        "id": 1761053,
-        "old_signatures": [
-          {
-            "signature": "5a84815bd324703c235b20c58e8f9eb1471e4046",
-            "id": 1654529,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "f3f8c68fefcc7bda160f98a6253ce5bf64e96ffa",
-        "id": 1760793,
-        "old_signatures": [
-          {
-            "signature": "f3f8c68fefcc7bda160f98a6253ce5bf64e96ffa",
-            "id": 1652283,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.webconsole.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "29b3ffc1392e9ec87b8704d1854b0e5c41138cab",
-            "id": 1654686,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "cedaae342c20a2ae0167ee58e6389629ea3e3bed",
-            "id": 1655268,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "254df731db37d165a8ca4b380bf5286be073ef9b",
-            "id": 1654011,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "57fabca46c0ad14534b59b1eab40166f7b637b81",
-            "id": 1656378,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7ab817b16db7c06deda1b76959ab4d43d88a7347",
-            "id": 1649613,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "4ed1c0980137f63d5da048a9a5489fc7ea8b39b4",
-            "id": 1654530,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "4085f64e59b65b27119734847d63fb1f78cb44be",
-            "id": 1652284,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "custom.webconsole.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "dd0ec03f6fc8802f0e867adc5c1b7d72712e9894",
-        "id": 1760599,
-        "old_signatures": [
-          {
-            "signature": "dd0ec03f6fc8802f0e867adc5c1b7d72712e9894",
-            "id": 1654687,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "667a34afb9dd6d45d2f242bf70a5b6126498e0c2",
-        "id": 1761249,
-        "old_signatures": [
-          {
-            "signature": "667a34afb9dd6d45d2f242bf70a5b6126498e0c2",
-            "id": 1655270,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "6dffeabddb8ef283c27e26b46ba31f7e2229ac82",
-        "id": 1760924,
-        "old_signatures": [
-          {
-            "signature": "6dffeabddb8ef283c27e26b46ba31f7e2229ac82",
-            "id": 1654012,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "c5b17b3731efcf6d8c43735cbba5e12540587afe",
-        "id": 1761314,
-        "old_signatures": [
-          {
-            "signature": "c5b17b3731efcf6d8c43735cbba5e12540587afe",
-            "id": 1656379,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "3778a98abbae34fdbafdec03e60695781ef17435",
-        "id": 1760404,
-        "old_signatures": [
-          {
-            "signature": "3778a98abbae34fdbafdec03e60695781ef17435",
-            "id": 1649614,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "87429c5a2a213871be4e16fda9376f1a1dbba460",
-        "id": 1761054,
-        "old_signatures": [
-          {
-            "signature": "87429c5a2a213871be4e16fda9376f1a1dbba460",
-            "id": 1654531,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "668fb8521d744313f7c0dabd4dcfc97a524dbed2",
-        "id": 1760794,
-        "old_signatures": [
-          {
-            "signature": "668fb8521d744313f7c0dabd4dcfc97a524dbed2",
-            "id": 1652285,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "custom.webconsole.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "882f673af5c424310c4ccff6fe36f291e9fcc67b",
-            "id": 1654688,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "8cab913e7042991c21a25b323c1ac72494b0de7b",
-            "id": 1655271,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bae2f9eeb57514f8f5a93fdbbe1aa7fc089e9e08",
-            "id": 1654013,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "5215e312fcfb6d4ae44713b17f99e1f3f25e0ba3",
-            "id": 1656380,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7a9335807203af402eb57e33587386e6fc95f8ef",
-            "id": 1649615,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "306598c743700c00370c3e07eca68520d8129b27",
-            "id": 1654532,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0b6f6fecda1674868f0a860d1f054323a4be3ecd",
-            "id": 1652286,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "inspector.layout.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "1536f0c05e567807b3c977fc5f137e26a82a7ba8",
-        "id": 1760624,
-        "old_signatures": [
-          {
-            "signature": "1536f0c05e567807b3c977fc5f137e26a82a7ba8",
-            "id": 1654705,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "77efab2f2ab21ce53132aaf27d2cb7492d61f6ef",
-        "id": 1761274,
-        "old_signatures": [
-          {
-            "signature": "77efab2f2ab21ce53132aaf27d2cb7492d61f6ef",
-            "id": 1655307,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "f2d2a071cbd04dd81844f8425f9fb5361e432914",
-        "id": 1760949,
-        "old_signatures": [
-          {
-            "signature": "f2d2a071cbd04dd81844f8425f9fb5361e432914",
-            "id": 1654030,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "52407dacbab0cffaec1b6ff4984de214b7de4fa5",
-        "id": 1761339,
-        "old_signatures": [
-          {
-            "signature": "52407dacbab0cffaec1b6ff4984de214b7de4fa5",
-            "id": 1656397,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "4af1b4a7b1b849070343ed8898b9b9f3a242d73e",
-        "id": 1760429,
-        "old_signatures": [
-          {
-            "signature": "4af1b4a7b1b849070343ed8898b9b9f3a242d73e",
-            "id": 1649634,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "e32b8c386fcdd8ed909e03ab1e343002899f3ddf",
-        "id": 1761079,
-        "old_signatures": [
-          {
-            "signature": "e32b8c386fcdd8ed909e03ab1e343002899f3ddf",
-            "id": 1654551,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c5b9b4c80b5b724b26da361bbf837359b0ebb960",
-        "id": 1760819,
-        "old_signatures": [
-          {
-            "signature": "c5b9b4c80b5b724b26da361bbf837359b0ebb960",
-            "id": 1652303,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "inspector.mutations": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b123e6efdb4f8c30e1516adab5cd3a3cf83c1e1f",
-        "id": 1760623,
-        "old_signatures": [
-          {
-            "signature": "b123e6efdb4f8c30e1516adab5cd3a3cf83c1e1f",
-            "id": 1654704,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "d88447763d2a2a5eaba6cc8fa863c4368017fb71",
-        "id": 1761273,
-        "old_signatures": [
-          {
-            "signature": "d88447763d2a2a5eaba6cc8fa863c4368017fb71",
-            "id": 1655305,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "0b82213b7cd982364667364258c2dfc8d29c911d",
-        "id": 1760948,
-        "old_signatures": [
-          {
-            "signature": "0b82213b7cd982364667364258c2dfc8d29c911d",
-            "id": 1654029,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "728d96e90991b11a3748f9150590147dfe89fa0f",
-        "id": 1761338,
-        "old_signatures": [
-          {
-            "signature": "728d96e90991b11a3748f9150590147dfe89fa0f",
-            "id": 1656396,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "4b210e20bf8cbd9568e99e3933cf925fb443f89c",
-        "id": 1760428,
-        "old_signatures": [
-          {
-            "signature": "4b210e20bf8cbd9568e99e3933cf925fb443f89c",
-            "id": 1649633,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "b648df19bf6c7a83af87767704202cc33a93a0a6",
-        "id": 1761078,
-        "old_signatures": [
-          {
-            "signature": "b648df19bf6c7a83af87767704202cc33a93a0a6",
-            "id": 1654550,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "d75ae880132f86a937df1006d4af324e1dc11d78",
-        "id": 1760818,
-        "old_signatures": [
-          {
-            "signature": "d75ae880132f86a937df1006d4af324e1dc11d78",
-            "id": 1652302,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "panelsInBackground.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "0761732e23f0530808487dbaae322e8657f15b3f",
-        "id": 1760625,
-        "old_signatures": [
-          {
-            "signature": "0761732e23f0530808487dbaae322e8657f15b3f",
-            "id": 1654706,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "1dfab7b033854b437854e082e734a0c1e4afb9e4",
-        "id": 1761275,
-        "old_signatures": [
-          {
-            "signature": "1dfab7b033854b437854e082e734a0c1e4afb9e4",
-            "id": 1655309,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "8f98c6f33053cc8ca8227a6207912049e5fa1cd4",
-        "id": 1760950,
-        "old_signatures": [
-          {
-            "signature": "8f98c6f33053cc8ca8227a6207912049e5fa1cd4",
-            "id": 1654031,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "7586bb0df3c97189be0baed252011a8c453e234f",
-        "id": 1761340,
-        "old_signatures": [
-          {
-            "signature": "7586bb0df3c97189be0baed252011a8c453e234f",
-            "id": 1656398,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "8162e49bb18dc47ca6862d045aa19b219dd7d5fa",
-        "id": 1760430,
-        "old_signatures": [
-          {
-            "signature": "8162e49bb18dc47ca6862d045aa19b219dd7d5fa",
-            "id": 1649635,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "0708696dd176b6f11563b761bdff11e1912ce648",
-        "id": 1761080,
-        "old_signatures": [
-          {
-            "signature": "0708696dd176b6f11563b761bdff11e1912ce648",
-            "id": 1654552,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "e00737a6dae5ec76d12186cd6025188ab19c1c1d",
-        "id": 1760820,
-        "old_signatures": [
-          {
-            "signature": "e00737a6dae5ec76d12186cd6025188ab19c1c1d",
-            "id": 1652304,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "panelsInBackground.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0a87ebeb7a540fbb6f664bc2befa3b4880c7a8ec",
-            "id": 1654707,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e0e83d9708c66b8b5998cb6b4f5f1f90792e39fb",
-            "id": 1655311,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c477a1ce6fc8b7d3a995332e4164ab58447dc21e",
-            "id": 1654032,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "b53247881c77ac53bfd9299051cc9b2f79cf82a2",
-            "id": 1656399,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "77e061bb336e3bcf189bc791cc059da263c501d8",
-            "id": 1649636,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0ab90f19ef3758f4a12a471e1dc57884b8279bef",
-            "id": 1654553,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bedbb45120e6835bd64a8dc620e61ef13445e4a2",
-            "id": 1652305,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "server.protocoljs": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "5e0148d5b58b634e86c1e9e363b58d41b13e6ab6",
-        "id": 1760626,
-        "old_signatures": [
-          {
-            "signature": "5e0148d5b58b634e86c1e9e363b58d41b13e6ab6",
-            "id": 1682556,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "3cdb675ece7211de28248ba70c395f6611b55629",
-        "id": 1761276,
-        "old_signatures": [
-          {
-            "signature": "3cdb675ece7211de28248ba70c395f6611b55629",
-            "id": 1682559,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "1e1848a79458c58ed04503e66aab1d154fa9b9db",
-        "id": 1760951,
-        "old_signatures": [
-          {
-            "signature": "1e1848a79458c58ed04503e66aab1d154fa9b9db",
-            "id": 1682555,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "bec8323c62d855e70bed4e0c455ad69d023f5122",
-        "id": 1761341,
-        "old_signatures": [
-          {
-            "signature": "bec8323c62d855e70bed4e0c455ad69d023f5122",
-            "id": 1682560,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "1fb5e5aa6e50348e1828f40f1f4a2185d3db2bd8",
-        "id": 1760431,
-        "old_signatures": [
-          {
-            "signature": "1fb5e5aa6e50348e1828f40f1f4a2185d3db2bd8",
-            "id": 1682550,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "1bd628cffa7f4fa51e901a9963c842f26ff8c2ac",
-        "id": 1761081,
-        "old_signatures": [
-          {
-            "signature": "1bd628cffa7f4fa51e901a9963c842f26ff8c2ac",
-            "id": 1682553,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "2ea6549d4878c56feaa86f8c77df71f1006dfec7",
-        "id": 1760821,
-        "old_signatures": [
-          {
-            "signature": "2ea6549d4878c56feaa86f8c77df71f1006dfec7",
-            "id": 1682554,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.inspector.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "9c25496e819bc2feed0001d3929d843a81044e8e",
-        "id": 1760569,
-        "old_signatures": [
-          {
-            "signature": "9c25496e819bc2feed0001d3929d843a81044e8e",
-            "id": 1539646,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a47b210cbcb56d3efd707e5eafec0d2edd6f8ba7",
-        "id": 1761219,
-        "old_signatures": [
-          {
-            "signature": "a47b210cbcb56d3efd707e5eafec0d2edd6f8ba7",
-            "id": 1539024,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "daefed59599f269eb7224ad2227a70209eeb9da1",
-        "id": 1760894,
-        "old_signatures": [
-          {
-            "signature": "daefed59599f269eb7224ad2227a70209eeb9da1",
-            "id": 1538281,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "95133f33af911ff05bcae6bdd3fc88cbd55d0f61",
-        "id": 1761284,
-        "old_signatures": [
-          {
-            "signature": "95133f33af911ff05bcae6bdd3fc88cbd55d0f61",
-            "id": 1539041,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "c58b0e57d17065d3942c02832ce506139de4f2f2",
-        "id": 1760374,
-        "old_signatures": [
-          {
-            "signature": "c58b0e57d17065d3942c02832ce506139de4f2f2",
-            "id": 1649543,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "73501b03fa397cf32478b5674307a409c1ae5870",
-        "id": 1761024,
-        "old_signatures": [
-          {
-            "signature": "73501b03fa397cf32478b5674307a409c1ae5870",
-            "id": 1654460,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "ae4719494e30ad2f95e969aa5656dba7fbce3aa2",
-        "id": 1760764,
-        "old_signatures": [
-          {
-            "signature": "ae4719494e30ad2f95e969aa5656dba7fbce3aa2",
-            "id": 1542641,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.inspector.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "2959ebdddfb5765a9de137b2c62aa452d8f5abc1",
-        "id": 1760567,
-        "old_signatures": [
-          {
-            "signature": "2959ebdddfb5765a9de137b2c62aa452d8f5abc1",
-            "id": 1539644,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "757cfe590847079c9571da6543609588d7e831ad",
-        "id": 1761217,
-        "old_signatures": [
-          {
-            "signature": "757cfe590847079c9571da6543609588d7e831ad",
-            "id": 1539022,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "50c51d61dbc6cef5cc0420afe30a7353ea96d95e",
-        "id": 1760892,
-        "old_signatures": [
-          {
-            "signature": "50c51d61dbc6cef5cc0420afe30a7353ea96d95e",
-            "id": 1538279,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "ec8e72615f54530ecba24eb85e8e856b3266be8f",
-        "id": 1761282,
-        "old_signatures": [
-          {
-            "signature": "ec8e72615f54530ecba24eb85e8e856b3266be8f",
-            "id": 1539036,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "bc8539457aa768b118a8a2e4dbff1e346d92dade",
-        "id": 1760372,
-        "old_signatures": [
-          {
-            "signature": "bc8539457aa768b118a8a2e4dbff1e346d92dade",
-            "id": 1649539,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "ca95ae244d5cb2ce60290a4ed4483696ab7ba77b",
-        "id": 1761022,
-        "old_signatures": [
-          {
-            "signature": "ca95ae244d5cb2ce60290a4ed4483696ab7ba77b",
-            "id": 1654456,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c435d1a12ac4b93c534158338810432761286e8f",
-        "id": 1760762,
-        "old_signatures": [
-          {
-            "signature": "c435d1a12ac4b93c534158338810432761286e8f",
-            "id": 1542639,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.inspector.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1491ca9a233926eff5c168211a88b6745cdf9d1e",
-            "id": 1654659,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a1e66d7535bbfe85df3418c512b8598f81b8927a",
-            "id": 1655187,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f8cc771188a70e723a7fd494b72bfcfe9897592b",
-            "id": 1653984,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "358c926bda470cf48ac6912769a4e2ed130df81a",
-            "id": 1656351,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "1500f6682fb9d529768d6ee393eaa0042e6d1687",
-            "id": 1649540,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e36c449bbc5122b7df9fec3558a416e87ddc2fd4",
-            "id": 1654457,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "3d363f11a0069960f5d282bc13ddf1ff533d5eeb",
-            "id": 1652257,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.inspector.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "ad9afa3a6506c4e179ab9461e7c6a2b9903601db",
-        "id": 1760568,
-        "old_signatures": [
-          {
-            "signature": "ad9afa3a6506c4e179ab9461e7c6a2b9903601db",
-            "id": 1539645,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "41bb89820ac47c34f35c6e9e5d0547a9b67f21d7",
-        "id": 1761218,
-        "old_signatures": [
-          {
-            "signature": "41bb89820ac47c34f35c6e9e5d0547a9b67f21d7",
-            "id": 1539023,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "c26142c1316ecd45e3b5ee906f64fea6e7efdc48",
-        "id": 1760893,
-        "old_signatures": [
-          {
-            "signature": "c26142c1316ecd45e3b5ee906f64fea6e7efdc48",
-            "id": 1538280,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "010f4ede4ed430f2677b0f2ac88e5f9b3f264f95",
-        "id": 1761283,
-        "old_signatures": [
-          {
-            "signature": "010f4ede4ed430f2677b0f2ac88e5f9b3f264f95",
-            "id": 1539038,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "3d83793788276d9cc299561ccfbc3ce9efa5114e",
-        "id": 1760373,
-        "old_signatures": [
-          {
-            "signature": "3d83793788276d9cc299561ccfbc3ce9efa5114e",
-            "id": 1649541,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "adcabd1022c892de196394d3cbb3b1fd7aea7132",
-        "id": 1761023,
-        "old_signatures": [
-          {
-            "signature": "adcabd1022c892de196394d3cbb3b1fd7aea7132",
-            "id": 1654458,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "5409501a21691be43068e3ff527b67adc814b570",
-        "id": 1760763,
-        "old_signatures": [
-          {
-            "signature": "5409501a21691be43068e3ff527b67adc814b570",
-            "id": 1542640,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.inspector.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ca38c566100ed56b3b7707c18617360c798efd72",
-            "id": 1654660,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ad9d41d04be5d824a73a58f3b5fabab024fc56b5",
-            "id": 1655192,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ceebf0a22a64f8d3fffd04fe970a8ebcb8e85d46",
-            "id": 1653985,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "194ca3edbc70bd483c92650a3a61d59102205a78",
-            "id": 1656352,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "b0bad2d06616942a2423bc7460217213a582a39f",
-            "id": 1649542,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a894c00895848aca4048356bf42c3a8988dbb1cc",
-            "id": 1654459,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "651fc13f3bccde4c189f4a578b5decaaf7ea4416",
-            "id": 1652258,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.jsdebugger.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "f3609c9a3864643e5d02786d92bf22b933c21efa",
-        "id": 1760572,
-        "old_signatures": [
-          {
-            "signature": "f3609c9a3864643e5d02786d92bf22b933c21efa",
-            "id": 1539649,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "d9a552c0421c44062e5e36b9ce1bce81e424257c",
-        "id": 1761222,
-        "old_signatures": [
-          {
-            "signature": "d9a552c0421c44062e5e36b9ce1bce81e424257c",
-            "id": 1539028,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "baa78e462f57b4a8300f122f54420deaf28898df",
-        "id": 1760897,
-        "old_signatures": [
-          {
-            "signature": "baa78e462f57b4a8300f122f54420deaf28898df",
-            "id": 1538284,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "bd9429d1f8de953300151c5d48cd4d61eb517be0",
-        "id": 1761287,
-        "old_signatures": [
-          {
-            "signature": "bd9429d1f8de953300151c5d48cd4d61eb517be0",
-            "id": 1539050,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "0772629b333a4d11f67ac9ff09876e7d61b23630",
-        "id": 1760377,
-        "old_signatures": [
-          {
-            "signature": "0772629b333a4d11f67ac9ff09876e7d61b23630",
-            "id": 1649548,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "6fe2ae7ff141fc3e61dc0bac5a31f0972bb10c1a",
-        "id": 1761027,
-        "old_signatures": [
-          {
-            "signature": "6fe2ae7ff141fc3e61dc0bac5a31f0972bb10c1a",
-            "id": 1654465,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "5fe189232f6fe96019285ca835298dc5f25cdda1",
-        "id": 1760767,
-        "old_signatures": [
-          {
-            "signature": "5fe189232f6fe96019285ca835298dc5f25cdda1",
-            "id": 1542644,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.jsdebugger.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "ee3145b583b49bf87c33ada0920f580c374c8164",
-        "id": 1760570,
-        "old_signatures": [
-          {
-            "signature": "ee3145b583b49bf87c33ada0920f580c374c8164",
-            "id": 1539647,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "92183d723c04bdb024432abf4a4145897067174b",
-        "id": 1761220,
-        "old_signatures": [
-          {
-            "signature": "92183d723c04bdb024432abf4a4145897067174b",
-            "id": 1539025,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4fbb26cfdb4d67e4be5ced36bbb7e299de7be2aa",
-        "id": 1760895,
-        "old_signatures": [
-          {
-            "signature": "4fbb26cfdb4d67e4be5ced36bbb7e299de7be2aa",
-            "id": 1538282,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "ece4b6e119ca22a337b7edf7183bd3fa1158697a",
-        "id": 1761285,
-        "old_signatures": [
-          {
-            "signature": "ece4b6e119ca22a337b7edf7183bd3fa1158697a",
-            "id": 1539044,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "123d54019780bc67dbce5049094f2825fa50538e",
-        "id": 1760375,
-        "old_signatures": [
-          {
-            "signature": "123d54019780bc67dbce5049094f2825fa50538e",
-            "id": 1649544,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "f5a396d11d2ed70d491fb66c2a25422f73e013ba",
-        "id": 1761025,
-        "old_signatures": [
-          {
-            "signature": "f5a396d11d2ed70d491fb66c2a25422f73e013ba",
-            "id": 1654461,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "568c76c45861816474ec9189f228cea4ecf70b8c",
-        "id": 1760765,
-        "old_signatures": [
-          {
-            "signature": "568c76c45861816474ec9189f228cea4ecf70b8c",
-            "id": 1542642,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.jsdebugger.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "fa97d026d75c63103e99ac533175c1638a22ac06",
-            "id": 1654661,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "aecaf2bf9387fb0d86c0397255adf055abc7a7c2",
-            "id": 1655198,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "905c8ffef032cc45ffb741afebcf8afc92b77648",
-            "id": 1653986,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "95d97f708d3c4bcca7070ed779f209b5d45ff963",
-            "id": 1656353,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2920ebc1984ea0645bcfe83f977f49a06c58eead",
-            "id": 1649545,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2e1de7b4efed6503fe97085fda7f7a1b37e864d9",
-            "id": 1654462,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "fc9c6d56f7ecf6285eb956ed0873fffe40eca23c",
-            "id": 1652259,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.jsdebugger.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "0e02982aba50cac892efbde266da9d6ec24c9800",
-        "id": 1760571,
-        "old_signatures": [
-          {
-            "signature": "0e02982aba50cac892efbde266da9d6ec24c9800",
-            "id": 1539648,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "ba9f6b9cade4b49c56ce0c4a4447f74023029f58",
-        "id": 1761221,
-        "old_signatures": [
-          {
-            "signature": "ba9f6b9cade4b49c56ce0c4a4447f74023029f58",
-            "id": 1539026,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "e553784931a7197054437e3d953800d232a02211",
-        "id": 1760896,
-        "old_signatures": [
-          {
-            "signature": "e553784931a7197054437e3d953800d232a02211",
-            "id": 1538283,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "d8f8a22496e0f33df07a59d59493076d02c2a1a3",
-        "id": 1761286,
-        "old_signatures": [
-          {
-            "signature": "d8f8a22496e0f33df07a59d59493076d02c2a1a3",
-            "id": 1539047,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "666064acda23e09aa5621f108af35f3a4a4bb86f",
-        "id": 1760376,
-        "old_signatures": [
-          {
-            "signature": "666064acda23e09aa5621f108af35f3a4a4bb86f",
-            "id": 1649546,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "8f91ee78fec525dac6cba8dda0cb1d43da0f0533",
-        "id": 1761026,
-        "old_signatures": [
-          {
-            "signature": "8f91ee78fec525dac6cba8dda0cb1d43da0f0533",
-            "id": 1654463,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "f57471809fe0b81b9579144685a086e3413e7832",
-        "id": 1760766,
-        "old_signatures": [
-          {
-            "signature": "f57471809fe0b81b9579144685a086e3413e7832",
-            "id": 1542643,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.jsdebugger.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "eb055f9cb6ce0803fa64919147cdf68779a6e3f9",
-            "id": 1654662,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bceae330e83b3c4988e70d42e0ff1bd4d4353d83",
-            "id": 1655200,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "25da834e83c0f7c6fdc3f7609fc8e32f41d638c1",
-            "id": 1653987,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "34351e8aa80c33e7a971f112177f82dd5babe008",
-            "id": 1656354,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "eb3b608b0bf4ed7104153f28db9bc32dfdfba919",
-            "id": 1649547,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "6aa20f0e43b3a665507d6ceadd1b9c223713faac",
-            "id": 1654464,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "d16558e3bd53b3c30cb992831052b8263065068e",
-            "id": 1652260,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.netmonitor.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "f4e45416d805b7120ba69bb10197b17db5b2ed22",
-        "id": 1760580,
-        "old_signatures": [
-          {
-            "signature": "f4e45416d805b7120ba69bb10197b17db5b2ed22",
-            "id": 1539659,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "3e7e8c240c015d3cf47018783aa3582ed7359c2a",
-        "id": 1761230,
-        "old_signatures": [
-          {
-            "signature": "3e7e8c240c015d3cf47018783aa3582ed7359c2a",
-            "id": 1539057,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "b4a6aae029c50ae1d368997b8f370b8c7ea427b9",
-        "id": 1760905,
-        "old_signatures": [
-          {
-            "signature": "b4a6aae029c50ae1d368997b8f370b8c7ea427b9",
-            "id": 1538294,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "1c6814d6aa3a004180da1561afc7c630a982b045",
-        "id": 1761295,
-        "old_signatures": [
-          {
-            "signature": "1c6814d6aa3a004180da1561afc7c630a982b045",
-            "id": 1539094,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "9014a728694eccc964d3970302d51284836a40b9",
-        "id": 1760385,
-        "old_signatures": [
-          {
-            "signature": "9014a728694eccc964d3970302d51284836a40b9",
-            "id": 1649564,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "2340996ddd23fcb9f9cfd1008a8788ecc16fab71",
-        "id": 1761035,
-        "old_signatures": [
-          {
-            "signature": "2340996ddd23fcb9f9cfd1008a8788ecc16fab71",
-            "id": 1654481,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "bf98a3f0053a704e76e964294442e7dbbdd6c920",
-        "id": 1760775,
-        "old_signatures": [
-          {
-            "signature": "bf98a3f0053a704e76e964294442e7dbbdd6c920",
-            "id": 1542654,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.netmonitor.exportHar": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "f347c1da87ca1dade790d09d9f00240848b884e2",
-        "id": 1760579,
-        "old_signatures": [
-          {
-            "signature": "f347c1da87ca1dade790d09d9f00240848b884e2",
-            "id": 1668811,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "79eedd8a6bdc11e86fc50014139c4ea56c830488",
-        "id": 1761229,
-        "old_signatures": [
-          {
-            "signature": "79eedd8a6bdc11e86fc50014139c4ea56c830488",
-            "id": 1668813,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "1b2c1b6c8111f5712c68e4ba2a7c4d7513459b97",
-        "id": 1760904,
-        "old_signatures": [
-          {
-            "signature": "1b2c1b6c8111f5712c68e4ba2a7c4d7513459b97",
-            "id": 1668809,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "e26a275e0455dd989e84808835c4f7c6af6f881c",
-        "id": 1761294,
-        "old_signatures": [
-          {
-            "signature": "e26a275e0455dd989e84808835c4f7c6af6f881c",
-            "id": 1668814,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "a50a1b74726116f2aa2a172e3ca5ba80fe0b84fe",
-        "id": 1760384,
-        "old_signatures": [
-          {
-            "signature": "a50a1b74726116f2aa2a172e3ca5ba80fe0b84fe",
-            "id": 1668799,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "faee2a830f1c981d8bb9a28ce1e5035e91e7945e",
-        "id": 1761034,
-        "old_signatures": [
-          {
-            "signature": "faee2a830f1c981d8bb9a28ce1e5035e91e7945e",
-            "id": 1668803,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "17667fc06d5f845a595b32ae577418cceb4d99ab",
-        "id": 1760774,
-        "old_signatures": [
-          {
-            "signature": "17667fc06d5f845a595b32ae577418cceb4d99ab",
-            "id": 1668805,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.netmonitor.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "09277b4dce643ec5e553682d79f2a985f3416de2",
-        "id": 1760576,
-        "old_signatures": [
-          {
-            "signature": "09277b4dce643ec5e553682d79f2a985f3416de2",
-            "id": 1539656,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "cd2a2ae32144cc3e7d77d970f4dfb3ff1b74d3a7",
-        "id": 1761226,
-        "old_signatures": [
-          {
-            "signature": "cd2a2ae32144cc3e7d77d970f4dfb3ff1b74d3a7",
-            "id": 1539048,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "8b2b6b3cccfce1b2762b5cfa29c31b94305292f4",
-        "id": 1760901,
-        "old_signatures": [
-          {
-            "signature": "8b2b6b3cccfce1b2762b5cfa29c31b94305292f4",
-            "id": 1538291,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "8d324eb760ce3de3b302b47da26fedc14fd1d1e3",
-        "id": 1761291,
-        "old_signatures": [
-          {
-            "signature": "8d324eb760ce3de3b302b47da26fedc14fd1d1e3",
-            "id": 1539081,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "5f56b8f5aea9e2205c7f96b64b0ebed5830bd6ad",
-        "id": 1760381,
-        "old_signatures": [
-          {
-            "signature": "5f56b8f5aea9e2205c7f96b64b0ebed5830bd6ad",
-            "id": 1649559,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "cb255a6e0f8c68eed956c07f28031bd957a8745a",
-        "id": 1761031,
-        "old_signatures": [
-          {
-            "signature": "cb255a6e0f8c68eed956c07f28031bd957a8745a",
-            "id": 1654476,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "286d1e71a9796afffeea68e70bc2609008ba4699",
-        "id": 1760771,
-        "old_signatures": [
-          {
-            "signature": "286d1e71a9796afffeea68e70bc2609008ba4699",
-            "id": 1542651,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.netmonitor.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "77f3111ac7208792950e5f3a1bff6d82f1b768df",
-            "id": 1654667,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "794da8bc8406be2e7e4f4bad1f66f4544241b997",
-            "id": 1655214,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "52de1352b1e9c78d720dd0e7475150edfa657341",
-            "id": 1653992,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "13ea69d5aa15bfbf129a9136ebe13abae22896b7",
-            "id": 1656359,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "4367c090b3ebce9715a4f569d86d0f02120efb79",
-            "id": 1649560,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f135d3074ac4b1d62e26bbd6dd158d437024812e",
-            "id": 1654477,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "4946d39cd817e06380b01c1e1d403c3b2b43b73b",
-            "id": 1652265,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.netmonitor.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "37617f2f9d2050085cdb0cab634db2d7e77d5860",
-        "id": 1760577,
-        "old_signatures": [
-          {
-            "signature": "37617f2f9d2050085cdb0cab634db2d7e77d5860",
-            "id": 1539657,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "683e2f57d0a42066bd27546f2ca17ea2c99e46bb",
-        "id": 1761227,
-        "old_signatures": [
-          {
-            "signature": "683e2f57d0a42066bd27546f2ca17ea2c99e46bb",
-            "id": 1539051,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "5009f9daed7343948378fb26147c605489bb3121",
-        "id": 1760902,
-        "old_signatures": [
-          {
-            "signature": "5009f9daed7343948378fb26147c605489bb3121",
-            "id": 1538292,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "547584bd1d035f02fdda59a824ff749bbe5b9888",
-        "id": 1761292,
-        "old_signatures": [
-          {
-            "signature": "547584bd1d035f02fdda59a824ff749bbe5b9888",
-            "id": 1539085,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "fa1e4630d16647657f02322e3a8ed2f251bdb221",
-        "id": 1760382,
-        "old_signatures": [
-          {
-            "signature": "fa1e4630d16647657f02322e3a8ed2f251bdb221",
-            "id": 1649561,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "b0f89327264df8c56a4d7644d96ffd16ac86646f",
-        "id": 1761032,
-        "old_signatures": [
-          {
-            "signature": "b0f89327264df8c56a4d7644d96ffd16ac86646f",
-            "id": 1654478,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "2163754a1c87312ed1f7b6e91fdd5f524a69274e",
-        "id": 1760772,
-        "old_signatures": [
-          {
-            "signature": "2163754a1c87312ed1f7b6e91fdd5f524a69274e",
-            "id": 1542652,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.netmonitor.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "288bd5103f76667f05a59d8e61469d9a663d515e",
-            "id": 1654668,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "0c95378bffec6f10ecc5bcbef4b7d1e95bbe42d4",
-            "id": 1655216,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "d02f058845ddb85be982d84aa428bfc6bc1669b2",
-            "id": 1653993,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2ef6b85f022e7f17c3bde731176a1031e3d3159d",
-            "id": 1656360,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "806e64db6b977d5d76ded96f1ca29688ede4b161",
-            "id": 1649562,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a92655c5324470c37dc4c337616a2e557dd9735f",
-            "id": 1654479,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "2558b1f7411cfe1b0495bb38d9a79f6c0345a56f",
-            "id": 1652266,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.netmonitor.requestsFinished": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "8da863a108a8b0f3f5ae6f4e33c6df51333477fc",
-        "id": 1760578,
-        "old_signatures": [
-          {
-            "signature": "8da863a108a8b0f3f5ae6f4e33c6df51333477fc",
-            "id": 1539658,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "1f79cb16d1059f50aa8d49d3be5df44935a13ff2",
-        "id": 1761228,
-        "old_signatures": [
-          {
-            "signature": "1f79cb16d1059f50aa8d49d3be5df44935a13ff2",
-            "id": 1539055,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "a0888da203ddb5389c1f2d7444eebbb21a9144e3",
-        "id": 1760903,
-        "old_signatures": [
-          {
-            "signature": "a0888da203ddb5389c1f2d7444eebbb21a9144e3",
-            "id": 1538293,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "13119f1b5300368793a69843968a86dad2d47eeb",
-        "id": 1761293,
-        "old_signatures": [
-          {
-            "signature": "13119f1b5300368793a69843968a86dad2d47eeb",
-            "id": 1539090,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "b7f49c9ff6cab97aa6a4cb7265dfcf9c166486da",
-        "id": 1760383,
-        "old_signatures": [
-          {
-            "signature": "b7f49c9ff6cab97aa6a4cb7265dfcf9c166486da",
-            "id": 1649563,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "304ba05bb95c2252aae085bfd3abdf2852e72dbe",
-        "id": 1761033,
-        "old_signatures": [
-          {
-            "signature": "304ba05bb95c2252aae085bfd3abdf2852e72dbe",
-            "id": 1654480,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "31062f64ce2e8917d5f2db7cbb4a5d7dffbd795e",
-        "id": 1760773,
-        "old_signatures": [
-          {
-            "signature": "31062f64ce2e8917d5f2db7cbb4a5d7dffbd795e",
-            "id": 1542653,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.styleeditor.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "b8e3ee6b73d76b9f9275aae12ac7d3820234d6a9",
-        "id": 1760575,
-        "old_signatures": [
-          {
-            "signature": "b8e3ee6b73d76b9f9275aae12ac7d3820234d6a9",
-            "id": 1539652,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "e04151cf0e318364135371925685d8a8989e498f",
-        "id": 1761225,
-        "old_signatures": [
-          {
-            "signature": "e04151cf0e318364135371925685d8a8989e498f",
-            "id": 1539035,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4f938be09669a3b5123f07bcd787b2b835798c0c",
-        "id": 1760900,
-        "old_signatures": [
-          {
-            "signature": "4f938be09669a3b5123f07bcd787b2b835798c0c",
-            "id": 1538287,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "478e510f574ba909364222699bacbeb3e7aeb887",
-        "id": 1761290,
-        "old_signatures": [
-          {
-            "signature": "478e510f574ba909364222699bacbeb3e7aeb887",
-            "id": 1539061,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "db84cdb28d841c06b61f0aa9e31a2f4ed62b33b1",
-        "id": 1760380,
-        "old_signatures": [
-          {
-            "signature": "db84cdb28d841c06b61f0aa9e31a2f4ed62b33b1",
-            "id": 1649553,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "e2b158e250dff45d4c1a34fc1937d85921313209",
-        "id": 1761030,
-        "old_signatures": [
-          {
-            "signature": "e2b158e250dff45d4c1a34fc1937d85921313209",
-            "id": 1654470,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "f9351c8ead36b8fd0f686fbd07a5a6efae37214d",
-        "id": 1760770,
-        "old_signatures": [
-          {
-            "signature": "f9351c8ead36b8fd0f686fbd07a5a6efae37214d",
-            "id": 1542647,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.styleeditor.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "73fc57e0ce3afe84a5baddfb47959b89d4bb04b0",
-        "id": 1760573,
-        "old_signatures": [
-          {
-            "signature": "73fc57e0ce3afe84a5baddfb47959b89d4bb04b0",
-            "id": 1539650,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "662431ffcd444d4b8ac9a95466c40ea35ccc7414",
-        "id": 1761223,
-        "old_signatures": [
-          {
-            "signature": "662431ffcd444d4b8ac9a95466c40ea35ccc7414",
-            "id": 1539030,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "0823b450d1d9f7c779a156941cfc57e4daa239fa",
-        "id": 1760898,
-        "old_signatures": [
-          {
-            "signature": "0823b450d1d9f7c779a156941cfc57e4daa239fa",
-            "id": 1538285,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "25cc57acc5212e4904dea0eecb186abb20888d9e",
-        "id": 1761288,
-        "old_signatures": [
-          {
-            "signature": "25cc57acc5212e4904dea0eecb186abb20888d9e",
-            "id": 1539053,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "3c05bd1c548b096dd124ebe22ab3220c645fa8f2",
-        "id": 1760378,
-        "old_signatures": [
-          {
-            "signature": "3c05bd1c548b096dd124ebe22ab3220c645fa8f2",
-            "id": 1649549,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "943d6cee94e32bbe1acad6bcb551dd96f73ecace",
-        "id": 1761028,
-        "old_signatures": [
-          {
-            "signature": "943d6cee94e32bbe1acad6bcb551dd96f73ecace",
-            "id": 1654466,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "c8a4cd477190d744aa4012aef16f9ba3c7c82914",
-        "id": 1760768,
-        "old_signatures": [
-          {
-            "signature": "c8a4cd477190d744aa4012aef16f9ba3c7c82914",
-            "id": 1542645,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.styleeditor.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "534837cdb280e0648655b330e987490fb619a463",
-            "id": 1654663,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "fc7afe4f66ae68b801de3717a5c939a4bdfadab8",
-            "id": 1655203,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bad28b121cc0cc3d3764641c8661dcb83765fb35",
-            "id": 1653988,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ed9b265e67becfd43fb762de077727ad783f8d4e",
-            "id": 1656355,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "d4b67a57185cc9b5ef0b9872aba1cd82f5f596f1",
-            "id": 1649550,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "484884ae130d80f1e9d51cb0324e74eb9b5e4bf2",
-            "id": 1654467,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "8431ff3be68e1b93c2e4a29070045d7671c3a7de",
-            "id": 1652261,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.styleeditor.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "09bc46368ce4d20afff1a7531b6b8aea86df477b",
-        "id": 1760574,
-        "old_signatures": [
-          {
-            "signature": "09bc46368ce4d20afff1a7531b6b8aea86df477b",
-            "id": 1539651,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "ab62abfe1f4f834333ad9be54f7838081138a7d2",
-        "id": 1761224,
-        "old_signatures": [
-          {
-            "signature": "ab62abfe1f4f834333ad9be54f7838081138a7d2",
-            "id": 1539032,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "756523f61a6fee870bf2156cd17c5106dacb5d36",
-        "id": 1760899,
-        "old_signatures": [
-          {
-            "signature": "756523f61a6fee870bf2156cd17c5106dacb5d36",
-            "id": 1538286,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "bc16a32227052626daafbc8c4f20b32af2b4d06f",
-        "id": 1761289,
-        "old_signatures": [
-          {
-            "signature": "bc16a32227052626daafbc8c4f20b32af2b4d06f",
-            "id": 1539058,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "1f9ce1f3fd3947b0277bf15accc4c88ef42ac7ed",
-        "id": 1760379,
-        "old_signatures": [
-          {
-            "signature": "1f9ce1f3fd3947b0277bf15accc4c88ef42ac7ed",
-            "id": 1649551,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "716d2df9050a1dafd217dd6bda5571b7bc0f02cc",
-        "id": 1761029,
-        "old_signatures": [
-          {
-            "signature": "716d2df9050a1dafd217dd6bda5571b7bc0f02cc",
-            "id": 1654468,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "33c6617e6400d9e57bbe137918d5fb33dce228ed",
-        "id": 1760769,
-        "old_signatures": [
-          {
-            "signature": "33c6617e6400d9e57bbe137918d5fb33dce228ed",
-            "id": 1542646,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.styleeditor.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a9477f2e4afdd5bf37bcbe3d238c33ea10235b14",
-            "id": 1654664,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e6121b1f5b818847dd0f5e23c544097d1ef135bf",
-            "id": 1655205,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "bae3000317d31ad97e60cfd9f8dbf975117af18c",
-            "id": 1653989,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f099084aadfae43c7816d747ce28c4127569d777",
-            "id": 1656356,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7806f693f5f945c74db5fc1fdc30c6acaefe999b",
-            "id": 1649552,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "025d9f1c731f562dc2fef1025cd35e63aced4641",
-            "id": 1654469,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "a01837273c22a93525ea63cdbf13d1c8d2dffe31",
-            "id": 1652262,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.webconsole.close": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "819f632c28e95f89759de375e0bf9748864f11eb",
-        "id": 1760566,
-        "old_signatures": [
-          {
-            "signature": "819f632c28e95f89759de375e0bf9748864f11eb",
-            "id": 1539643,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "60a46b9840745efa472379e4c926eb2e597ab3cb",
-        "id": 1761216,
-        "old_signatures": [
-          {
-            "signature": "60a46b9840745efa472379e4c926eb2e597ab3cb",
-            "id": 1539021,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "4ead15828f568587ef3c9c304ee151334ea3ab0d",
-        "id": 1760891,
-        "old_signatures": [
-          {
-            "signature": "4ead15828f568587ef3c9c304ee151334ea3ab0d",
-            "id": 1538278,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "9705111834abdced7c2e6ea5452a41868c3ed31c",
-        "id": 1761281,
-        "old_signatures": [
-          {
-            "signature": "9705111834abdced7c2e6ea5452a41868c3ed31c",
-            "id": 1539033,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "daf4bee26ef109d4d85771ec94bee788008b1ef4",
-        "id": 1760371,
-        "old_signatures": [
-          {
-            "signature": "daf4bee26ef109d4d85771ec94bee788008b1ef4",
-            "id": 1649538,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "f3e25d146d6eb998cd21e5615bc714cd2bd0373a",
-        "id": 1761021,
-        "old_signatures": [
-          {
-            "signature": "f3e25d146d6eb998cd21e5615bc714cd2bd0373a",
-            "id": 1654455,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "27ba91ae3022df6d496e6bd643c8524f30dc7ecc",
-        "id": 1760761,
-        "old_signatures": [
-          {
-            "signature": "27ba91ae3022df6d496e6bd643c8524f30dc7ecc",
-            "id": 1542638,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.webconsole.open": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "41bc5591e0308719997dc53572b03fffb7d327c5",
-        "id": 1760564,
-        "old_signatures": [
-          {
-            "signature": "41bc5591e0308719997dc53572b03fffb7d327c5",
-            "id": 1539641,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "a6424283e617ce60fccdbe066dbc34a0c39e6f8d",
-        "id": 1761214,
-        "old_signatures": [
-          {
-            "signature": "a6424283e617ce60fccdbe066dbc34a0c39e6f8d",
-            "id": 1539019,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "e34293918e646aa4eca1861270a1aea8955e79bb",
-        "id": 1760889,
-        "old_signatures": [
-          {
-            "signature": "e34293918e646aa4eca1861270a1aea8955e79bb",
-            "id": 1538276,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "17c2cc2d5de8f57b7f851659acf6cb33aa23b294",
-        "id": 1761279,
-        "old_signatures": [
-          {
-            "signature": "17c2cc2d5de8f57b7f851659acf6cb33aa23b294",
-            "id": 1539029,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "95977e687acc3477da68170f1279f2999d73c0d9",
-        "id": 1760369,
-        "old_signatures": [
-          {
-            "signature": "95977e687acc3477da68170f1279f2999d73c0d9",
-            "id": 1649534,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "fcfdbaa2bf279c2f3e64f7f285b6c2e8debf0663",
-        "id": 1761019,
-        "old_signatures": [
-          {
-            "signature": "fcfdbaa2bf279c2f3e64f7f285b6c2e8debf0663",
-            "id": 1654451,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "ce136d4d14788ca69066360682ab630898b001bd",
-        "id": 1760759,
-        "old_signatures": [
-          {
-            "signature": "ce136d4d14788ca69066360682ab630898b001bd",
-            "id": 1542636,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.webconsole.open.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "ed3935591ffcff295c0934e1a95b3209c7d1ff67",
-            "id": 1654657,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "054217688c27600d00221518fde2c6c115fa6c49",
-            "id": 1655183,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c12175192da4001eb977c3e5424b4be44bf605a2",
-            "id": 1653982,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "e66244e78ab06d8e5bb67904a7923d98b3e5bb83",
-            "id": 1656349,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "17e3c0d26d7b9e90be28a220505271d524b0ff4f",
-            "id": 1649535,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "7ce290f630234c7c8b7062452679d85ca4ddf657",
-            "id": 1654452,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "f6018cbc6c3e4cfe6c3da3b3243ade326a2be4f2",
-            "id": 1652255,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      }
-    }
-  },
-  "simple.webconsole.reload": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "1e40d91f136d71bc61b0c5c7c22ad9e562fea290",
-        "id": 1760565,
-        "old_signatures": [
-          {
-            "signature": "1e40d91f136d71bc61b0c5c7c22ad9e562fea290",
-            "id": 1539642,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "69012dc37c1f4eef8e5b6d9f7ec5c8a49e486139",
-        "id": 1761215,
-        "old_signatures": [
-          {
-            "signature": "69012dc37c1f4eef8e5b6d9f7ec5c8a49e486139",
-            "id": 1539020,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "071a68da94cbe6783d3d1cca01e10a33f07a08f8",
-        "id": 1760890,
-        "old_signatures": [
-          {
-            "signature": "071a68da94cbe6783d3d1cca01e10a33f07a08f8",
-            "id": 1538277,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "077945697fbdd87e0bd9da59a02d2877b7c7f114",
-        "id": 1761280,
-        "old_signatures": [
-          {
-            "signature": "077945697fbdd87e0bd9da59a02d2877b7c7f114",
-            "id": 1539031,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "1614bbbd62b03e02ea93241f5c122b56486d2453",
-        "id": 1760370,
-        "old_signatures": [
-          {
-            "signature": "1614bbbd62b03e02ea93241f5c122b56486d2453",
-            "id": 1649536,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "284fbf4a22c968d83d7eee35045b5a3c7f5af92a",
-        "id": 1761020,
-        "old_signatures": [
-          {
-            "signature": "284fbf4a22c968d83d7eee35045b5a3c7f5af92a",
-            "id": 1654453,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "092b5784927acbeafba177b7e9f8fe6aa796dacb",
-        "id": 1760760,
-        "old_signatures": [
-          {
-            "signature": "092b5784927acbeafba177b7e9f8fe6aa796dacb",
-            "id": 1542637,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ],
-        "framework": 12
-      }
-    }
-  },
-  "simple.webconsole.reload.settle": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "8752e48edb32e7295f35af8015a808ca1dfbe26e",
-            "id": 1654658,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows7-32-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "aecde8203c687d199e72428d4e14851cba79f152",
-            "id": 1655184,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "445978225e23c67d38be63f6d883d4a4f89ed2dc",
-            "id": 1653983,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "windows10-64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "06d9cde3e92906c75a9655a67107a2878d29b8d3",
-            "id": 1656350,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "74a75d170dd159006bf6e7aacda967870a9225b9",
-            "id": 1649537,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "linux64-pgo": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "9057d4f83e500689df3d09105eb3c64b96ea595c",
-            "id": 1654454,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
-      },
-      "osx-10-10-opt": {
-        "signature": null,
-        "id": null,
-        "old_signatures": [
-          {
-            "signature": "c238758d6264e88c6c12921cdf5060b4041b38c6",
-            "id": 1652256,
-            "framework": 1,
-            "before": 1534284000000
-          }
-        ]
       }
     }
   },
@@ -8792,6 +157,1086 @@ const PerfHerderSignatures = {
       }
     }
   },
+  "complicated.inspector.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b7f624daa73e971e36152c16934cf9c4c9d4e8f5",
+        "id": 1760586,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "1b0081a95becbc1bb66f146747c5bbd4947c65ba",
+        "id": 1761236,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "3409ce5a386eb37e4df1e0d7c7b348459197ddd5",
+        "id": 1760911,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "ca6bd87c43503c3c9fa38e94acb5ecd3d114744e",
+        "id": 1761301,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "e6a72c92fb7f84b33b17e776756e08e6e0e8a8f9",
+        "id": 1760391,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "d7424265f0f927b870db2c1ded29218999d248bb",
+        "id": 1761041,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "b6c6658b10a2ad447d7c6c0eb75e56f375c516ca",
+        "id": 1760781,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.inspector.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "2b910c2eeba6c8ddbd4ddeb3c46ab3e7bee5ad5f",
+        "id": 1760584,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "0da14803ccd551bd6c152a191ce46170451dab0f",
+        "id": 1761234,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "007cb478c4c3686bc227d65bfe4fbf9e52c7e171",
+        "id": 1760909,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "ea121aea77be73e88646daeeae7ac8ffd6e9a095",
+        "id": 1761299,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "db299ac114d1f5ff89b8c0a41b27bab19f4c0c51",
+        "id": 1760389,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "fb515ef3c8374463918c5947e9f91e4909aedcf8",
+        "id": 1761039,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c95aa15a753d9fb128b37349932e73413349aed9",
+        "id": 1760779,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.inspector.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "3d161f7ba7086b83675da84ca55ac19ba0bb9a58",
+        "id": 1760585,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "4b1c7719ec651d0c5fa7be4cde11eb5ec324dd0e",
+        "id": 1761235,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "8dc367a5e5b15f482667853facac248a513b51f8",
+        "id": 1760910,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "93866d84946f2442755d82fe393743612e160c8c",
+        "id": 1761300,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "9438fe01afb26eab3d43bac8b09de5123d59ae2e",
+        "id": 1760390,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "b1bff4e07a610268bc01273c5c634d076527fee0",
+        "id": 1761040,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "9bc5647bfce1a6f9f0603ecee39bdc77b125f611",
+        "id": 1760780,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.jsdebugger.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "daa0684c9dc259a935cb0fb2ec879a4f8898aae2",
+        "id": 1760589,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "fad7dd04d26a5384dd8660b10e6e74af7c278dbc",
+        "id": 1761239,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4e1fa3dcac185e333633303660b28b886c3c054d",
+        "id": 1760914,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "b7fbc150bf385a7532ffdd95dd87963900342ced",
+        "id": 1761304,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "01a48a65cc0406d65a648ca7777d755e3115eaee",
+        "id": 1760394,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "fbbc0c5aa54c10ad34fd47b6bfa90ee4eee52500",
+        "id": 1761044,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "ad98a19382269e4da1ec31ca4ab313e3d8785595",
+        "id": 1760784,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.jsdebugger.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "feaa3690bbacca1448fee2af716615518a32f628",
+        "id": 1760587,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "3da5755babcdbb89a4b8e3b2f4e6927e9d68abc1",
+        "id": 1761237,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "99004e108af7dc62837f92ec9ea7c73dc0d172fc",
+        "id": 1760912,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "c3459d23df4a6655b3ec23e629eaf90af6302fcc",
+        "id": 1761302,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "3adac34e5e1fb79c06b80625920a9b0b76b12d5f",
+        "id": 1760392,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "282645ae33d2d3025c06204da0dde0a936cd2b11",
+        "id": 1761042,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "b48cc63f6ecdf0af242d54cc055567aabbaf4fc0",
+        "id": 1760782,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.jsdebugger.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "c928d511ba65453fd5427bdace953d6b9a455dec",
+        "id": 1760588,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "e1fbd375db9555ead277540af902e0a91acffad5",
+        "id": 1761238,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "f9de681fc7f192f147299d9c36b61e41085b2f5b",
+        "id": 1760913,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "5bbf597daa6eebc3c417df4e3529e53b3b715b8a",
+        "id": 1761303,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "63194a9fb5bf2a19af5e45b9ba507e08a68157ed",
+        "id": 1760393,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "9e325cc34e6de95e2408fbf36e3240d469b5cd93",
+        "id": 1761043,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "9e7dd5932b6f4680d34ec827ea4508b7df94fc4b",
+        "id": 1760783,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.netmonitor.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b3059e47ab8fd79887bc7c69cd3bf17235afb5c6",
+        "id": 1760597,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "6fcda28e2fc6eeefb137a698aa319aa588b06a78",
+        "id": 1761247,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0e641c9704f5cff8c8e823403483910650e6efe6",
+        "id": 1760922,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "ffc1538363be9f7ab7b459c81221a0398d9ca1e3",
+        "id": 1761312,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "2de1f58d829ebf59179090a590529409ead7d207",
+        "id": 1760402,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "795fd01fba0a8de4df6fe8b006d6517fe3ef110f",
+        "id": 1761052,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "f90859f08e2040b059a37c10d4bbfa0cc889aad0",
+        "id": 1760792,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.netmonitor.exportHar": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "6108a397d3aeedb9cd2260732e8d22708aceabdc",
+        "id": 1760596,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "f686d5f33068063f5fb0cc33ffbed7f5974294d1",
+        "id": 1761246,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "ade33e40355950b8cb1501e74555e7800394b6c8",
+        "id": 1760921,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "3a11fb6aff0d978fdd048c40d99eb51ff92ad020",
+        "id": 1761311,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "935faaf13b5c5cd9b78b4851804320eea67dbc1b",
+        "id": 1760401,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "43c7c7dcf3662fa575c4639c97e1cdd64ee7ac88",
+        "id": 1761051,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "6a45c0ffb341d2649f724a0771b6b1308acc8825",
+        "id": 1760791,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.netmonitor.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "54aef1de540fcbc1d588991683b0b4550a5b003b",
+        "id": 1760593,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "56cfd90fe8470a1df759766a08567a58005a8c1a",
+        "id": 1761243,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "45d66273b901685c84a2e4c143e686edcc7a8fb5",
+        "id": 1760918,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "94c7c1744c6d3b44b54e929ed60545cd6e884549",
+        "id": 1761308,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "a829d97a075d511bbbca238ad36f420b46bc6c2c",
+        "id": 1760398,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "7c6d23ab92b551a20f01418f0ec0658d6b169695",
+        "id": 1761048,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c2ebc4e5ed81535c7c5adca2afcb0f96eea3ca72",
+        "id": 1760788,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.netmonitor.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "1ae6d0ccab36d3d95cefbf345bc2d6c7667835a7",
+        "id": 1760594,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "e2b668d9216d94f76b2800f07caefcee78b88ee4",
+        "id": 1761244,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4f5054ef4194c2fe8af14e7cdb8947f6bc9dd6bb",
+        "id": 1760919,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "344218eb5d4cc56c25813cae0c5411f2f961e0ee",
+        "id": 1761309,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "adcab331a70cfd234d0b42c06687c3ea96cd0535",
+        "id": 1760399,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "4ef53cf4e3a6b2677ec4c23bf100dd7aaf996b7a",
+        "id": 1761049,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "913fee75317c4b51c8ad09cb36f8dcadb5adaf75",
+        "id": 1760789,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.netmonitor.requestsFinished": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "4277c12f4a9a1b16c59d56d61ee18e760a7c0d6b",
+        "id": 1760595,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "f4fb2079504ff5935e7c19609bd4efa77d99221e",
+        "id": 1761245,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "c0593c68649271014f173674fc2721942a1882db",
+        "id": 1760920,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "60afeb088b4b853812011e69e4422b8e3cbffe12",
+        "id": 1761310,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "c5ed310296444acb3515536648fab1812527b3d1",
+        "id": 1760400,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "74948c0737bdf76aa962e057b47f47feede8996c",
+        "id": 1761050,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "b6a2299f76b7f147830900315ab82b9f71581784",
+        "id": 1760790,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.styleeditor.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "556abd694c808840ae9e139396cb8faa4d85da35",
+        "id": 1760592,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "ea0dc95ba0d22990f19a669b0287befe96c8e341",
+        "id": 1761242,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "88271215eac1271235cd6d7bfcb0ac37a6008cf1",
+        "id": 1760917,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "51d4895ecf1e6ab11ef40c8bcdc697b2e5502fa2",
+        "id": 1761307,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "ef9a07d9fe64dd94dd7a57a094d329defcb8a7e8",
+        "id": 1760397,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "99f50ab4f7ca3144644c518bab47c8aaeceee9ed",
+        "id": 1761047,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "d06c0f2feb7169bee79607f37405f265bf051f2e",
+        "id": 1760787,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.styleeditor.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "08d23f93ae105fe023935ec9c42ff5775da72ba3",
+        "id": 1760590,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "63eba2b7086049839895afe37296622e633bc687",
+        "id": 1761240,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "119a69488b336b468d438927c62549b895ef1e7c",
+        "id": 1760915,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "92d4e7132ccbe1f6156fb77f62aef81406f43c17",
+        "id": 1761305,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "73d5c526dd4deb10d7e3bd01508703e75a17850b",
+        "id": 1760395,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "0fb7c78277878642e9f016bf00dfc5ac64e6bcd7",
+        "id": 1761045,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "39c057c5a3a4779146e0a99d145575b5180300df",
+        "id": 1760785,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.styleeditor.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "da1678e53b92f62297e2a48beddf7afadafbfd77",
+        "id": 1760591,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "fa5dc71bbb9b12c7c49dc192d0a597cdc079d649",
+        "id": 1761241,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "6816252593fa4ded443d58651b243a27981d4204",
+        "id": 1760916,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "a68a94b0548bfc0d329889fb0fe3f6294c5fbeab",
+        "id": 1761306,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "b8b69e494f9886b00ff98143ef0fd62f25248a84",
+        "id": 1760396,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "eaca97f9a79609ee2a6b0a87aa0cfaccf20f1618",
+        "id": 1761046,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "1f91027f887f3e4fc65d3388bb89d883ca3f1cd2",
+        "id": 1760786,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.webconsole.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "376d56fce6598fc6e9f06a7acfa9198a2aece31f",
+        "id": 1760583,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "c4729dea54b9a8d313d5209d86536b0be1a447f3",
+        "id": 1761233,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "188d859463f5d658bd1448ac8ccca0e9006c8aa2",
+        "id": 1760908,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "659dddf77d66fadc854aec301b8b8c1ad92ac49e",
+        "id": 1761298,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "9b0bbf2ea023e080cdfd9a77e0915d2d46293b83",
+        "id": 1760388,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "a519a7395bc93e5c29f3cd8b8e939f0a45dfd06c",
+        "id": 1761038,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "35fb1261bd1162fa1594a0a0ff80af4e81cc3027",
+        "id": 1760778,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.webconsole.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "7e4f9bc41206489c4ea9ea0bc58bd58a51f93074",
+        "id": 1760581,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "ef31076b53aa9114d461b861dba6e1b1c40efe00",
+        "id": 1761231,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "419bec5cb54e2b8081594dae3e5ff6c0b9d61309",
+        "id": 1760906,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "3adabb863066d79a923ab27f5545c039ba8b15a0",
+        "id": 1761296,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "5e273b93875f10482d4ab2f6f31a3398d769bb6d",
+        "id": 1760386,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "6599f8b6a38145c116337212286197946ea38fcf",
+        "id": 1761036,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "d64e2ac7edf41b832db83e9978470786ef8a834b",
+        "id": 1760776,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "complicated.webconsole.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "0fbc038982a367696566c8e5fa09ce6b72003e9f",
+        "id": 1760582,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "776b9c360d720ecd93c583d3468daa1ce7989f16",
+        "id": 1761232,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "88d15829227ecea9ffaca6fd7ad287e23beb9dda",
+        "id": 1760907,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "73b1cce2a5c278319a366c327d84ea19af80843e",
+        "id": 1761297,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "ad373754e919e41067b2f4788b2ff9b0d88dd86f",
+        "id": 1760387,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "06632a464fcae8eeafa6246c834acd84c43d851b",
+        "id": 1761037,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "9e5f2685e8ffee8585f96fd93bfc5111f5c22cdf",
+        "id": 1760777,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.autocomplete": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "e25e10aeeec007ac780c230a2503988c34347a4e",
+        "id": 1760618,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "feff187641eb21701861bcbd5896e504029914a5",
+        "id": 1761268,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "8479c9c0c7054c78a7977aaddabc4a4f63b026e5",
+        "id": 1760943,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "f61e942f0ce7d1906da19543bcc3ddded327e761",
+        "id": 1761333,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "0278f6f740f18a96b43d0baeace4ffb0a35f064e",
+        "id": 1760423,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "00fd75c22fa18b7ff3b54a69dbdb3fbebb1b17c9",
+        "id": 1761073,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "de3f444654c8a1f83d20df9ad9f685bf6492d546",
+        "id": 1760813,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.autocomplete.longInput": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "90ac346cc2cdee2494cb63e28f8429e05383402c",
+        "id": 2092756,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0d6699a630e124591c3fa76f0155634b536b8845",
+        "id": 2092757,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "8dfcfd8a8cc22c944e51c3eab6be0ed8de4f2a50",
+        "id": 2092754,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.bulklog": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "db81a5d13d30568d5c15765aecff7001ac7c88a1",
+        "id": 1760617,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "3ebe094bf174dde78108535acf57399a3ecee0df",
+        "id": 1761267,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "300288dc3bbe95c671cc51108a8bcb360768589b",
+        "id": 1760942,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "c443da532210865d5902853a62a2649ab1735ab7",
+        "id": 1761332,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "e5a0446f5f248c6490695dd2d90ec608175957c9",
+        "id": 1760422,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "6758cecba0cf4d2b048648ee657f5c541c3c157c",
+        "id": 1761072,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "96f15af34024a9373cec4cc03a6aaf8a00ed8ad2",
+        "id": 1760812,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.objectexpand": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "cecba81df61dff9fda652dbb1a77326e507cfcd5",
+        "id": 1760620,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "4ee3029bb70e429a064e7788c8b845b1a116248f",
+        "id": 1761270,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "28c867a96d2e41cb3428c096f569e9d2089391df",
+        "id": 1760945,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "eca3c7266d17aaaab1f00de6b0fb70438fd4f4f6",
+        "id": 1761335,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "31f7776cd76a6058f6dbf380be3dcecf650a8c0b",
+        "id": 1760425,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "a1a748e1c38d2a9d01c07091fe5a2f59ee4f30c0",
+        "id": 1761075,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "9febe43c04703458dfcbd7df1d22ff25900b3798",
+        "id": 1760815,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.objectexpanded.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "bc1cf0fe5ecf781af339b2739ed483e3a3be3d80",
+        "id": 1760621,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "570e06c012b8ffe1c7fc217357972cd9ce28c277",
+        "id": 1761271,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "aaefd257d5e25ef88fe06867cc2a0084f2cbbc10",
+        "id": 1760946,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "df33420e6f9ea5e82ae6b7dd640c9acba5d52f1c",
+        "id": 1761336,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "b0e8f4dcb75883dffceee221f35c044274d3c624",
+        "id": 1760426,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "6d413bcc545817d29d997e573ab5be08edd85080",
+        "id": 1761076,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "38712d8025e02f8a319f84a7218b5596d21ebbe9",
+        "id": 1760816,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.openwithcache.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b8bd7706560ae232ac2bc18fcc7b27750e59da42",
+        "id": 1760622,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "ffd1f0a82b5923c5dbecd61313eb7e82b520b345",
+        "id": 1761272,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "1ed55698ceaaea75966410c0fbbd3c67f6cc13d4",
+        "id": 1760947,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "0ea965fe139ba245e3b01c69047cb741d4f6115d",
+        "id": 1761337,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "b12966be150fb8d180683c9994b95b7b41717d8b",
+        "id": 1760427,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "864fbb1e6873ac43507c0cf27e75bf752600bcbe",
+        "id": 1761077,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "5fe65e2ffc0a9119dbe0e917cf8d1a7d8609fcb7",
+        "id": 1760817,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "console.streamlog": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "ac8ed43934946b4dbe8c04e69c09a3faf0a7c868",
+        "id": 1760619,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a4f43672d6a58f09e58e5767061132d84291ca81",
+        "id": 1761269,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0afec0b8791193fb419a58b0e405f26f4e756606",
+        "id": 1760944,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "8125a25776bba26d29a6ce0867605667e9d62a97",
+        "id": 1761334,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "95ca6e2f4bb93a07e52f3b5daa236570578e3e3a",
+        "id": 1760424,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "10beb945872afdd821b499d58d7f9209ca60bb4b",
+        "id": 1761074,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "fd76c8c981e076287bcbcdf1f96809f16287c022",
+        "id": 1760814,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
   "console.typing": {
     "platforms": {
       "windows7-32-opt": {
@@ -8838,6 +1283,580 @@ const PerfHerderSignatures = {
       }
     }
   },
+  "custom.inspector.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "60ec776cdbe6fe307bf5b5136e42a3014b4b2d81",
+        "id": 1760609,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a3b490795c60c181414c32bb4f1e6b86855ce7bb",
+        "id": 1761259,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "538d15e12e16c4cd1da35450962508ae2e6a505c",
+        "id": 1760934,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "9c2ee0821b08fd5880aaa681bc06ea079ea823e0",
+        "id": 1761324,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "ed44b53b68761edace9fc54831c6b3b2e99da789",
+        "id": 1760414,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "17a82fb0c17f471ea24b26ee68c3673cccffefcd",
+        "id": 1761064,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "f26b405b7a4eb657aeb031830eeb4b7b53228355",
+        "id": 1760804,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.collapseall.balanced": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b57d746f0ca2222590ab1930e2dbef650e08c4d2",
+        "id": 1760608,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "12955855421820c74bcfca3d964fdb277a5786dc",
+        "id": 1761258,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "89cca895530ffffe586c13a357364de764a5cf2d",
+        "id": 1760933,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "2e6f1a4585f22f6f166375c3e1a30cb06c2647ea",
+        "id": 1761323,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "e4e2177920f02792673589b094f5ed7b1f535a96",
+        "id": 1760413,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "18dedca3c3f19d8eb61403aabd4229d491efa002",
+        "id": 1761063,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "a51d40db8d43b1975d39e1e608f1fd6bb21957fc",
+        "id": 1760803,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.collapseall.manychildren": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "d0ecc7f767e58731a00f4ea594770eb3c64fdb3d",
+        "id": 1760606,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "f39c53ac6a2c256c4bc46449ba604a68731342fe",
+        "id": 1761256,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4d10c7a48800e10204915618036273f2eff2d2d7",
+        "id": 1760931,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "5e79d623284e3da9927c7d7cd9606db289db7c83",
+        "id": 1761321,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "62e13ef684cef1c52c89cc41c5da390c763aa653",
+        "id": 1760411,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "69a9919c36605c29cd235284e7871318322e265b",
+        "id": 1761061,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "47a0e46ce8f85d7dd972fd591206d25c603081d7",
+        "id": 1760801,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.expandall.balanced": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "ead7726d0d2b0e35baa721a2ff8252a053d483f5",
+        "id": 1760607,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "973b5d4e5868961b43bec0d6533eddd9ed9b3afa",
+        "id": 1761257,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "59da1c07433f9e90767db6a3be601d86c3f30fd4",
+        "id": 1760932,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "f7815d0d0f49ae2680d4ea6b1e7062362185a3cc",
+        "id": 1761322,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "071c79a5c33da0e3147318bc69a60eaaa9d1aaff",
+        "id": 1760412,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "a36450bf9e4fcd440681d7641f845836ff2d4dad",
+        "id": 1761062,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "7b6601f7e21f7c63f5f44267c029bb19fcae7c63",
+        "id": 1760802,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.expandall.manychildren": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "c0f0a0819480c48a5c16fe16d4744d34b8a7e068",
+        "id": 1760605,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "03ab439d3b745f3bf5145f9c79ff68b27ff94ee3",
+        "id": 1761255,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "80ad355f369824cfa9b238cbce39ec335a733980",
+        "id": 1760930,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "b790b56a44d75201ae23ebd8c044207be8ec326e",
+        "id": 1761320,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "2827dd590756caff04628f65c6f15710fce569c7",
+        "id": 1760410,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "41b372283739b2fc36406400f7fe01d9aa86377e",
+        "id": 1761060,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "4c8d1e397c97df7847e5eaa2305b4f664d6eca17",
+        "id": 1760800,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.manyrules.deselectnode": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "5df2100b57dbfb3fe591e68edac693a80845c431",
+        "id": 1760604,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "5ec9abef734d3a539837567a4d2e875d7b7af25b",
+        "id": 1761254,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4b1126b5bc0b70d6dcd065b8b27350c6ab94001c",
+        "id": 1760929,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "2e08d27fc847fffe3930e1f32d0a2fab77baa660",
+        "id": 1761319,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "308a29c813bc4f09b131fffcd0c6d1d1f55b5470",
+        "id": 1760409,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "2517f1804caaa7aaffce8534231c537dfeb04035",
+        "id": 1761059,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "97513decb49751b7d81c8a94fc3e6fdb78a6b448",
+        "id": 1760799,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.manyrules.selectnode": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b0a24944b2d6c29c2af9d75223c3d6cb0dc49df1",
+        "id": 1760603,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "c5378363a40f025761ee5ac41230c2bd3e297de7",
+        "id": 1761253,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "d02c62355f6fc106ac79ed925355c14cdc7ca519",
+        "id": 1760928,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "68613286e9e4ca5056945dc77854c09404522c7f",
+        "id": 1761318,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "e461295da6e3d4a6fa60edf4fb0204d3dba0d84f",
+        "id": 1760408,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "cfd2d45ccfc1d43d4373cb1f47ad8b0f51542d30",
+        "id": 1761058,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "639c7b7bbe1683b63c3cbb6267a1e2e6dfe9a661",
+        "id": 1760798,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "a092ecfa6abb9137e7f3e77fdffb83df74161a22",
+        "id": 1760601,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "e2ec96e182ce4a171399761578a7a573ffcdec53",
+        "id": 1761251,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "c6ac5b2ac017145f39af01cf9f5b6008aae3bd60",
+        "id": 1760926,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "5e8338139d7426ca57a1ee813b896612c79e1c56",
+        "id": 1761316,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "7dc6817d8889e93e5281bd863517e28d9a56e6fb",
+        "id": 1760406,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "a8b03818ef1c4b1982fe113a82293360b7028c34",
+        "id": 1761056,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "71d1a05de4ef30977ed9dd55f8e46d4dc4afc9a6",
+        "id": 1760796,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.inspector.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "0ea7359bbdc51abe74ee6fb06c80e93ee99fc479",
+        "id": 1760602,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "5814dfd8e08d6243515b396b1423a398e5c04e02",
+        "id": 1761252,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4dbcf10f692214140d6afd10bc8722b3bb93e7bf",
+        "id": 1760927,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "e2be806f19e2b909d2f19f831be886d778b0c2d3",
+        "id": 1761317,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "a27dbdaed8b47209a1f1d2e8f42b6a794dde29d7",
+        "id": 1760407,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "6faa35709ca9fff83216ad70671b459aed2ec31b",
+        "id": 1761057,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "31f6e406245c03b97f99c86fd3533afbfa888b84",
+        "id": 1760797,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "03d3b1f26439a1f4a0168c8539949f7d958dd036",
+        "id": 1760616,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "7c13ffa2159b37f37d7706207bda2c021fede32d",
+        "id": 1761266,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "657faba36123fae63791830fe9800a9cf7e5a6da",
+        "id": 1760941,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "f6753eaede93185719f89deff2a2ee6c204260ef",
+        "id": 1761331,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "2a1c95b7ff355ebcd18141cb6ac26f6307fdf99d",
+        "id": 1760421,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "10ccff7b55a48330a284d85766c0cb11e927ce4e",
+        "id": 1761071,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c8691e770ccef615f796f5009ae64d103d69ba60",
+        "id": 1760811,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "29cb6ad3bd290c5217c7935ac48af40d7835d38c",
+        "id": 1760610,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a9866b78c24f53b108dc0c51b471f01a2b4083df",
+        "id": 1761260,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "8451f14751ff89f9bfd4dae7390dab99088bd3d3",
+        "id": 1760935,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "55981f370d210fa549f9befaf8100a77ece9d2fc",
+        "id": 1761325,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "942e6714fc1a5624cc063d7d13f60414f813c7d7",
+        "id": 1760415,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "d8327d95e558a79bc1a61b3764ca25ae6ad7930a",
+        "id": 1761065,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "af243d74450bfd10967613c35a1245b76ea259a0",
+        "id": 1760805,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.pause": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "e48a906ff2548551b585549bed8e40be1cda3e74",
+        "id": 1760612,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a27a8f62b9e2cf72655922425ff202c7a96f5bab",
+        "id": 1761262,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "d70b820ddf74cdd6a200fcdc629f0af14235a092",
+        "id": 1760937,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "0f33e5e8645bf85eeb33095125a608545b777e9d",
+        "id": 1761327,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "13ba4fa720daf00b66320cf315715dba2e53b429",
+        "id": 1760417,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "24c7ab697210e88a75a042ef83ac1f3715d53671",
+        "id": 1761067,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "6d3c8f80d852a331471c4d1190d8680e5712909b",
+        "id": 1760807,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.preview": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "a94e7e6cb9ef54ccc56d53c32256f81572596711",
+        "id": 2059417,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "7c35e369826d920a5678b83340d965cb1b374e2f",
+        "id": 2059419,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "5cf97a000f6be3bed97502bfcaa29a42832367a5",
+        "id": 2059415,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
   "custom.jsdebugger.project-search": {
     "platforms": {
       "windows7-32-opt": {
@@ -8860,17 +1879,1305 @@ const PerfHerderSignatures = {
       }
     }
   },
-  "inspector-metrics.all-chars": {
+  "custom.jsdebugger.reload": {
     "platforms": {
+      "windows7-32-opt": {
+        "signature": "fb540659f1d9a7756497e3a0d065f94cb8df5dd9",
+        "id": 1760611,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "0a447de6a33dcf44fe3a2f591cf5c068fb385c9f",
+        "id": 1761261,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "6aa96350c4283bbf6bee1c07e7e883bedf692d2b",
+        "id": 1760936,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "11a8d22b76fe9e1b9183e99a3d7c65d01f25f6dc",
+        "id": 1761326,
+        "old_signatures": [],
+        "framework": 12
+      },
       "linux64-opt": {
-        "signature": "2df4c4d909dc9fda60f2bd22c0fbb25da70972d1",
-        "id": 1788274,
+        "signature": "f1b40e9f78c8b76b92848f248c77f49b5869b9c4",
+        "id": 1760416,
         "old_signatures": [],
         "framework": 12
       },
       "linux64-pgo": {
-        "signature": "c40fb2e6c50f06f3c8878224fb9a694638f51092",
-        "id": 1788330,
+        "signature": "bd75fee9d559b0a31f8831b2a505ff39f61cd11d",
+        "id": 1761066,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "7b75275679060c11bfce7d545736bd56bc5e07f9",
+        "id": 1760806,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.stepIn": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "f92b95e4f9362de27534dc069cd5db59ea5561e7",
+        "id": 1760613,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "11329565da785675a2f801d7379959835c04c2ee",
+        "id": 1761263,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "81e530ca2fd10dbca8344a759bc9c86dfcb2ca6a",
+        "id": 1760938,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "5c6560dc4a0854b862f5921b811e4bae50028807",
+        "id": 1761328,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "6f37c3ba3eb01e234e2dbc9c3d02544346d083cd",
+        "id": 1760418,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "e5beaac2183892fd1032edaddecc71296e0c7f39",
+        "id": 1761068,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "d5370df8b258789dbb58bfe87c2878ad676c21ff",
+        "id": 1760808,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.stepOut": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "6cab0854e637644aad510bd009dad1f44a0244ba",
+        "id": 1760615,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "aa7cd73e3e6e7527778b70be16d01068a288028b",
+        "id": 1761265,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0a7e16345804a32104c54b3cd9fa4b65b6397d11",
+        "id": 1760940,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "b4c86ea9a56f0c5350075c7bb348fdb8b39474f3",
+        "id": 1761330,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "9c53e48144fe27b59dfe5796879988bab7bb0d26",
+        "id": 1760420,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "543a46b650daf6bc46b0c58c2e69e7170717a636",
+        "id": 1761070,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "10f7fe3fa3236851ca5f3df6cbedd7a3d2b63336",
+        "id": 1760810,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.jsdebugger.stepOver": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "c9dec1559d576adadd067d0038e278084e65fb74",
+        "id": 1760614,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "500de38f0c32164d135236482e55e592bdfd2933",
+        "id": 1761264,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "9e471ecaf4c4bf72ef3d2a5d76a1c41989372f72",
+        "id": 1760939,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "be6b5f6c5813bc302d541ff3ae6a81c7bfd1b4a1",
+        "id": 1761329,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "cfed29cc140fd4f23bcfb20a15644fee011e3ad3",
+        "id": 1760419,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "2240cbe0958e108060710feb082d072a890c1ab4",
+        "id": 1761069,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "469af9d987e60ae6abee4cb583c6e1ad543db1ae",
+        "id": 1760809,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.webconsole.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "de570931bda5b3f2fc7daf9b4ce6baf8cf00dbbc",
+        "id": 1760600,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "bf7767e55ad2c96fcffb2cb3fbcc58abf284282f",
+        "id": 1761250,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "1eed0c74db9de1ac9b02c3a9c71109158d38e0af",
+        "id": 1760925,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "d4faea71c810d023f69f2ed3b2cb2b132750c97b",
+        "id": 1761315,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "f93a80d8632e2d8ef36c011edf4f38a9b66af0d4",
+        "id": 1760405,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "8f98334178a5ca3c8f912f0178b45b0ef78deae0",
+        "id": 1761055,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "2499e81e179a1cc4fde187fcd6af64679258ded7",
+        "id": 1760795,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.webconsole.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "5a41c8b243fe8ec5b6d20a3239167cb57070539b",
+        "id": 1760598,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "6c82dd9af436c0e8c674c4df6bdff7740924e1ee",
+        "id": 1761248,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "7f0a05c1f3274a0624709a3c49a010c170ecd9fb",
+        "id": 1760923,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "2b63cffbb426fe8e554e7c921df57c76fe78c25e",
+        "id": 1761313,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "99a80e257b1cf8839c630f5250f4d4ac74d4d59f",
+        "id": 1760403,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "5a84815bd324703c235b20c58e8f9eb1471e4046",
+        "id": 1761053,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "f3f8c68fefcc7bda160f98a6253ce5bf64e96ffa",
+        "id": 1760793,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "custom.webconsole.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "dd0ec03f6fc8802f0e867adc5c1b7d72712e9894",
+        "id": 1760599,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "667a34afb9dd6d45d2f242bf70a5b6126498e0c2",
+        "id": 1761249,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "6dffeabddb8ef283c27e26b46ba31f7e2229ac82",
+        "id": 1760924,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "c5b17b3731efcf6d8c43735cbba5e12540587afe",
+        "id": 1761314,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "3778a98abbae34fdbafdec03e60695781ef17435",
+        "id": 1760404,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "87429c5a2a213871be4e16fda9376f1a1dbba460",
+        "id": 1761054,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "668fb8521d744313f7c0dabd4dcfc97a524dbed2",
+        "id": 1760794,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "inspector.layout.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "1536f0c05e567807b3c977fc5f137e26a82a7ba8",
+        "id": 1760624,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "77efab2f2ab21ce53132aaf27d2cb7492d61f6ef",
+        "id": 1761274,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "f2d2a071cbd04dd81844f8425f9fb5361e432914",
+        "id": 1760949,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "52407dacbab0cffaec1b6ff4984de214b7de4fa5",
+        "id": 1761339,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "4af1b4a7b1b849070343ed8898b9b9f3a242d73e",
+        "id": 1760429,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "e32b8c386fcdd8ed909e03ab1e343002899f3ddf",
+        "id": 1761079,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c5b9b4c80b5b724b26da361bbf837359b0ebb960",
+        "id": 1760819,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "inspector.mutations": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b123e6efdb4f8c30e1516adab5cd3a3cf83c1e1f",
+        "id": 1760623,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "d88447763d2a2a5eaba6cc8fa863c4368017fb71",
+        "id": 1761273,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0b82213b7cd982364667364258c2dfc8d29c911d",
+        "id": 1760948,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "728d96e90991b11a3748f9150590147dfe89fa0f",
+        "id": 1761338,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "4b210e20bf8cbd9568e99e3933cf925fb443f89c",
+        "id": 1760428,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "b648df19bf6c7a83af87767704202cc33a93a0a6",
+        "id": 1761078,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "d75ae880132f86a937df1006d4af324e1dc11d78",
+        "id": 1760818,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "panelsInBackground.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "0761732e23f0530808487dbaae322e8657f15b3f",
+        "id": 1760625,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "1dfab7b033854b437854e082e734a0c1e4afb9e4",
+        "id": 1761275,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "8f98c6f33053cc8ca8227a6207912049e5fa1cd4",
+        "id": 1760950,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "7586bb0df3c97189be0baed252011a8c453e234f",
+        "id": 1761340,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "8162e49bb18dc47ca6862d045aa19b219dd7d5fa",
+        "id": 1760430,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "0708696dd176b6f11563b761bdff11e1912ce648",
+        "id": 1761080,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "e00737a6dae5ec76d12186cd6025188ab19c1c1d",
+        "id": 1760820,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "server.protocoljs": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "5e0148d5b58b634e86c1e9e363b58d41b13e6ab6",
+        "id": 1760626,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "3cdb675ece7211de28248ba70c395f6611b55629",
+        "id": 1761276,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "1e1848a79458c58ed04503e66aab1d154fa9b9db",
+        "id": 1760951,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "bec8323c62d855e70bed4e0c455ad69d023f5122",
+        "id": 1761341,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "1fb5e5aa6e50348e1828f40f1f4a2185d3db2bd8",
+        "id": 1760431,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "1bd628cffa7f4fa51e901a9963c842f26ff8c2ac",
+        "id": 1761081,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "2ea6549d4878c56feaa86f8c77df71f1006dfec7",
+        "id": 1760821,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.inspector.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "9c25496e819bc2feed0001d3929d843a81044e8e",
+        "id": 1760569,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a47b210cbcb56d3efd707e5eafec0d2edd6f8ba7",
+        "id": 1761219,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "daefed59599f269eb7224ad2227a70209eeb9da1",
+        "id": 1760894,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "95133f33af911ff05bcae6bdd3fc88cbd55d0f61",
+        "id": 1761284,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "c58b0e57d17065d3942c02832ce506139de4f2f2",
+        "id": 1760374,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "73501b03fa397cf32478b5674307a409c1ae5870",
+        "id": 1761024,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "ae4719494e30ad2f95e969aa5656dba7fbce3aa2",
+        "id": 1760764,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.inspector.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "2959ebdddfb5765a9de137b2c62aa452d8f5abc1",
+        "id": 1760567,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "757cfe590847079c9571da6543609588d7e831ad",
+        "id": 1761217,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "50c51d61dbc6cef5cc0420afe30a7353ea96d95e",
+        "id": 1760892,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "ec8e72615f54530ecba24eb85e8e856b3266be8f",
+        "id": 1761282,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "bc8539457aa768b118a8a2e4dbff1e346d92dade",
+        "id": 1760372,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "ca95ae244d5cb2ce60290a4ed4483696ab7ba77b",
+        "id": 1761022,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c435d1a12ac4b93c534158338810432761286e8f",
+        "id": 1760762,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.inspector.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "ad9afa3a6506c4e179ab9461e7c6a2b9903601db",
+        "id": 1760568,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "41bb89820ac47c34f35c6e9e5d0547a9b67f21d7",
+        "id": 1761218,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "c26142c1316ecd45e3b5ee906f64fea6e7efdc48",
+        "id": 1760893,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "010f4ede4ed430f2677b0f2ac88e5f9b3f264f95",
+        "id": 1761283,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "3d83793788276d9cc299561ccfbc3ce9efa5114e",
+        "id": 1760373,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "adcabd1022c892de196394d3cbb3b1fd7aea7132",
+        "id": 1761023,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "5409501a21691be43068e3ff527b67adc814b570",
+        "id": 1760763,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.jsdebugger.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "f3609c9a3864643e5d02786d92bf22b933c21efa",
+        "id": 1760572,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "d9a552c0421c44062e5e36b9ce1bce81e424257c",
+        "id": 1761222,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "baa78e462f57b4a8300f122f54420deaf28898df",
+        "id": 1760897,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "bd9429d1f8de953300151c5d48cd4d61eb517be0",
+        "id": 1761287,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "0772629b333a4d11f67ac9ff09876e7d61b23630",
+        "id": 1760377,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "6fe2ae7ff141fc3e61dc0bac5a31f0972bb10c1a",
+        "id": 1761027,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "5fe189232f6fe96019285ca835298dc5f25cdda1",
+        "id": 1760767,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.jsdebugger.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "ee3145b583b49bf87c33ada0920f580c374c8164",
+        "id": 1760570,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "92183d723c04bdb024432abf4a4145897067174b",
+        "id": 1761220,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4fbb26cfdb4d67e4be5ced36bbb7e299de7be2aa",
+        "id": 1760895,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "ece4b6e119ca22a337b7edf7183bd3fa1158697a",
+        "id": 1761285,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "123d54019780bc67dbce5049094f2825fa50538e",
+        "id": 1760375,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "f5a396d11d2ed70d491fb66c2a25422f73e013ba",
+        "id": 1761025,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "568c76c45861816474ec9189f228cea4ecf70b8c",
+        "id": 1760765,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.jsdebugger.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "0e02982aba50cac892efbde266da9d6ec24c9800",
+        "id": 1760571,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "ba9f6b9cade4b49c56ce0c4a4447f74023029f58",
+        "id": 1761221,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "e553784931a7197054437e3d953800d232a02211",
+        "id": 1760896,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "d8f8a22496e0f33df07a59d59493076d02c2a1a3",
+        "id": 1761286,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "666064acda23e09aa5621f108af35f3a4a4bb86f",
+        "id": 1760376,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "8f91ee78fec525dac6cba8dda0cb1d43da0f0533",
+        "id": 1761026,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "f57471809fe0b81b9579144685a086e3413e7832",
+        "id": 1760766,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.netmonitor.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "f4e45416d805b7120ba69bb10197b17db5b2ed22",
+        "id": 1760580,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "3e7e8c240c015d3cf47018783aa3582ed7359c2a",
+        "id": 1761230,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "b4a6aae029c50ae1d368997b8f370b8c7ea427b9",
+        "id": 1760905,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "1c6814d6aa3a004180da1561afc7c630a982b045",
+        "id": 1761295,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "9014a728694eccc964d3970302d51284836a40b9",
+        "id": 1760385,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "2340996ddd23fcb9f9cfd1008a8788ecc16fab71",
+        "id": 1761035,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "bf98a3f0053a704e76e964294442e7dbbdd6c920",
+        "id": 1760775,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.netmonitor.exportHar": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "f347c1da87ca1dade790d09d9f00240848b884e2",
+        "id": 1760579,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "79eedd8a6bdc11e86fc50014139c4ea56c830488",
+        "id": 1761229,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "1b2c1b6c8111f5712c68e4ba2a7c4d7513459b97",
+        "id": 1760904,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "e26a275e0455dd989e84808835c4f7c6af6f881c",
+        "id": 1761294,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "a50a1b74726116f2aa2a172e3ca5ba80fe0b84fe",
+        "id": 1760384,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "faee2a830f1c981d8bb9a28ce1e5035e91e7945e",
+        "id": 1761034,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "17667fc06d5f845a595b32ae577418cceb4d99ab",
+        "id": 1760774,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.netmonitor.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "09277b4dce643ec5e553682d79f2a985f3416de2",
+        "id": 1760576,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "cd2a2ae32144cc3e7d77d970f4dfb3ff1b74d3a7",
+        "id": 1761226,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "8b2b6b3cccfce1b2762b5cfa29c31b94305292f4",
+        "id": 1760901,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "8d324eb760ce3de3b302b47da26fedc14fd1d1e3",
+        "id": 1761291,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "5f56b8f5aea9e2205c7f96b64b0ebed5830bd6ad",
+        "id": 1760381,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "cb255a6e0f8c68eed956c07f28031bd957a8745a",
+        "id": 1761031,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "286d1e71a9796afffeea68e70bc2609008ba4699",
+        "id": 1760771,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.netmonitor.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "37617f2f9d2050085cdb0cab634db2d7e77d5860",
+        "id": 1760577,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "683e2f57d0a42066bd27546f2ca17ea2c99e46bb",
+        "id": 1761227,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "5009f9daed7343948378fb26147c605489bb3121",
+        "id": 1760902,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "547584bd1d035f02fdda59a824ff749bbe5b9888",
+        "id": 1761292,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "fa1e4630d16647657f02322e3a8ed2f251bdb221",
+        "id": 1760382,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "b0f89327264df8c56a4d7644d96ffd16ac86646f",
+        "id": 1761032,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "2163754a1c87312ed1f7b6e91fdd5f524a69274e",
+        "id": 1760772,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.netmonitor.requestsFinished": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "8da863a108a8b0f3f5ae6f4e33c6df51333477fc",
+        "id": 1760578,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "1f79cb16d1059f50aa8d49d3be5df44935a13ff2",
+        "id": 1761228,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "a0888da203ddb5389c1f2d7444eebbb21a9144e3",
+        "id": 1760903,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "13119f1b5300368793a69843968a86dad2d47eeb",
+        "id": 1761293,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "b7f49c9ff6cab97aa6a4cb7265dfcf9c166486da",
+        "id": 1760383,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "304ba05bb95c2252aae085bfd3abdf2852e72dbe",
+        "id": 1761033,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "31062f64ce2e8917d5f2db7cbb4a5d7dffbd795e",
+        "id": 1760773,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.styleeditor.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "b8e3ee6b73d76b9f9275aae12ac7d3820234d6a9",
+        "id": 1760575,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "e04151cf0e318364135371925685d8a8989e498f",
+        "id": 1761225,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4f938be09669a3b5123f07bcd787b2b835798c0c",
+        "id": 1760900,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "478e510f574ba909364222699bacbeb3e7aeb887",
+        "id": 1761290,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "db84cdb28d841c06b61f0aa9e31a2f4ed62b33b1",
+        "id": 1760380,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "e2b158e250dff45d4c1a34fc1937d85921313209",
+        "id": 1761030,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "f9351c8ead36b8fd0f686fbd07a5a6efae37214d",
+        "id": 1760770,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.styleeditor.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "73fc57e0ce3afe84a5baddfb47959b89d4bb04b0",
+        "id": 1760573,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "662431ffcd444d4b8ac9a95466c40ea35ccc7414",
+        "id": 1761223,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "0823b450d1d9f7c779a156941cfc57e4daa239fa",
+        "id": 1760898,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "25cc57acc5212e4904dea0eecb186abb20888d9e",
+        "id": 1761288,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "3c05bd1c548b096dd124ebe22ab3220c645fa8f2",
+        "id": 1760378,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "943d6cee94e32bbe1acad6bcb551dd96f73ecace",
+        "id": 1761028,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "c8a4cd477190d744aa4012aef16f9ba3c7c82914",
+        "id": 1760768,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.styleeditor.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "09bc46368ce4d20afff1a7531b6b8aea86df477b",
+        "id": 1760574,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "ab62abfe1f4f834333ad9be54f7838081138a7d2",
+        "id": 1761224,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "756523f61a6fee870bf2156cd17c5106dacb5d36",
+        "id": 1760899,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "bc16a32227052626daafbc8c4f20b32af2b4d06f",
+        "id": 1761289,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "1f9ce1f3fd3947b0277bf15accc4c88ef42ac7ed",
+        "id": 1760379,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "716d2df9050a1dafd217dd6bda5571b7bc0f02cc",
+        "id": 1761029,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "33c6617e6400d9e57bbe137918d5fb33dce228ed",
+        "id": 1760769,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.webconsole.close": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "819f632c28e95f89759de375e0bf9748864f11eb",
+        "id": 1760566,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "60a46b9840745efa472379e4c926eb2e597ab3cb",
+        "id": 1761216,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "4ead15828f568587ef3c9c304ee151334ea3ab0d",
+        "id": 1760891,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "9705111834abdced7c2e6ea5452a41868c3ed31c",
+        "id": 1761281,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "daf4bee26ef109d4d85771ec94bee788008b1ef4",
+        "id": 1760371,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "f3e25d146d6eb998cd21e5615bc714cd2bd0373a",
+        "id": 1761021,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "27ba91ae3022df6d496e6bd643c8524f30dc7ecc",
+        "id": 1760761,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.webconsole.open": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "41bc5591e0308719997dc53572b03fffb7d327c5",
+        "id": 1760564,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "a6424283e617ce60fccdbe066dbc34a0c39e6f8d",
+        "id": 1761214,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "e34293918e646aa4eca1861270a1aea8955e79bb",
+        "id": 1760889,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "17c2cc2d5de8f57b7f851659acf6cb33aa23b294",
+        "id": 1761279,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "95977e687acc3477da68170f1279f2999d73c0d9",
+        "id": 1760369,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "fcfdbaa2bf279c2f3e64f7f285b6c2e8debf0663",
+        "id": 1761019,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "ce136d4d14788ca69066360682ab630898b001bd",
+        "id": 1760759,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "simple.webconsole.reload": {
+    "platforms": {
+      "windows7-32-opt": {
+        "signature": "1e40d91f136d71bc61b0c5c7c22ad9e562fea290",
+        "id": 1760565,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-pgo": {
+        "signature": "69012dc37c1f4eef8e5b6d9f7ec5c8a49e486139",
+        "id": 1761215,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-opt": {
+        "signature": "071a68da94cbe6783d3d1cca01e10a33f07a08f8",
+        "id": 1760890,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows10-64-pgo": {
+        "signature": "077945697fbdd87e0bd9da59a02d2877b7c7f114",
+        "id": 1761280,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-opt": {
+        "signature": "1614bbbd62b03e02ea93241f5c122b56486d2453",
+        "id": 1760370,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "284fbf4a22c968d83d7eee35045b5a3c7f5af92a",
+        "id": 1761020,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "osx-10-10-opt": {
+        "signature": "092b5784927acbeafba177b7e9f8fe6aa796dacb",
+        "id": 1760760,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "debugger-metrics.summary": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "04f3238439cddeb3d74b867581ba85e33205657b",
+        "id": 1882502,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "660ab0e7dcc2eaa73c6d47a1037c34621c0172ee",
+        "id": 1882517,
         "old_signatures": [],
         "framework": 12
       }
@@ -8878,31 +3185,15 @@ const PerfHerderSignatures = {
   },
   "debugger-metrics.all-chars": {
     "platforms": {
-      "linux64-pgo": {
-        "signature": "f5eeca07629ac87a68f67b205158d05f8f274cad",
-        "id": 1882521,
-        "old_signatures": [],
-        "framework": 12
-      },
       "linux64-opt": {
         "signature": "dfdf0c55027fb46908b712baeb482771c001813c",
         "id": 1882506,
         "old_signatures": [],
         "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.all-chars": {
-    "platforms": {
-      "linux64-pgo": {
-        "signature": "95c7c0335712fe15de7276eb4815ed2e59c26911",
-        "id": 1882516,
-        "old_signatures": [],
-        "framework": 12
       },
-      "linux64-opt": {
-        "signature": "fd4f767546e07f7cc4db0690e070c04a8d47cb57",
-        "id": 1882511,
+      "linux64-pgo": {
+        "signature": "f5eeca07629ac87a68f67b205158d05f8f274cad",
+        "id": 1882521,
         "old_signatures": [],
         "framework": 12
       }
@@ -8919,54 +3210,6 @@ const PerfHerderSignatures = {
       "linux64-pgo": {
         "signature": "5454896ffe54da65711b21f3c622c4714671123e",
         "id": 1882520,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.all-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "475c7713d1b712eeefdcaec3ff039edd007a57ca",
-        "id": 1788273,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "4d3f8bfd95e145aa40ffe0f5ee9a863dbd23f817",
-        "id": 1788329,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.all-modules": {
-    "platforms": {
-      "linux64-pgo": {
-        "signature": "2b467584b4bf1a8324d0a46491bfed70bd31bab5",
-        "id": 1882515,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "7e2b7d87725be8bf3c8d58b51366358e06f6aa11",
-        "id": 1882510,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "webconsole-metrics.all-modules": {
-    "platforms": {
-      "linux64-pgo": {
-        "signature": "320871399666a591ff733ea141ac51b8c00d1854",
-        "id": 1881298,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "e9fd6c5f5547b5c456104b85e78d3c468dd6f8cf",
-        "id": 1881288,
         "old_signatures": [],
         "framework": 12
       }
@@ -9004,22 +3247,6 @@ const PerfHerderSignatures = {
       }
     }
   },
-  "debugger-metrics.summary": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "04f3238439cddeb3d74b867581ba85e33205657b",
-        "id": 1882502,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "660ab0e7dcc2eaa73c6d47a1037c34621c0172ee",
-        "id": 1882517,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
   "inspector-metrics.summary": {
     "platforms": {
       "linux64-opt": {
@@ -9027,10 +3254,24 @@ const PerfHerderSignatures = {
         "id": 1788270,
         "old_signatures": [],
         "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "1f9c128fc922d8960e9fc1747522a92a5a2bbbf3",
-        "id": 1788326,
+      }
+    }
+  },
+  "inspector-metrics.all-chars": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "2df4c4d909dc9fda60f2bd22c0fbb25da70972d1",
+        "id": 1788274,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "inspector-metrics.all-modules": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "475c7713d1b712eeefdcaec3ff039edd007a57ca",
+        "id": 1788273,
         "old_signatures": [],
         "framework": 12
       }
@@ -9043,12 +3284,6 @@ const PerfHerderSignatures = {
         "id": 1788272,
         "old_signatures": [],
         "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "f40e46d0e51abe7854707d2c40db6868ab847395",
-        "id": 1788328,
-        "old_signatures": [],
-        "framework": 12
       }
     }
   },
@@ -9057,12 +3292,6 @@ const PerfHerderSignatures = {
       "linux64-opt": {
         "signature": "802477185dfd6d33456c5a0adb9b54fa8f8ff342",
         "id": 1788271,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "b769f2d9f19c6913d447d42ce970a11bc4dee853",
-        "id": 1788327,
         "old_signatures": [],
         "framework": 12
       }
@@ -9084,21 +3313,33 @@ const PerfHerderSignatures = {
       }
     }
   },
-  "total-after-gc.after": {
+  "netmonitor-metrics.all-chars": {
     "platforms": {
       "linux64-opt": {
-        "signature": "d4ec8684faaca43476b8255c65c4a6b729fce266",
-        "id": 1977724,
+        "signature": "fd4f767546e07f7cc4db0690e070c04a8d47cb57",
+        "id": 1882511,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "95c7c0335712fe15de7276eb4815ed2e59c26911",
+        "id": 1882516,
         "old_signatures": [],
         "framework": 12
       }
     }
   },
-  "total-after-gc.before": {
+  "netmonitor-metrics.all-modules": {
     "platforms": {
       "linux64-opt": {
-        "signature": "47d1cc41853f6cfa37db5a9c2cd7834d19ec314f",
-        "id": 1977723,
+        "signature": "7e2b7d87725be8bf3c8d58b51366358e06f6aa11",
+        "id": 1882510,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "2b467584b4bf1a8324d0a46491bfed70bd31bab5",
+        "id": 1882515,
         "old_signatures": [],
         "framework": 12
       }
@@ -9146,6 +3387,26 @@ const PerfHerderSignatures = {
       }
     }
   },
+  "total-after-gc.after": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "d4ec8684faaca43476b8255c65c4a6b729fce266",
+        "id": 1977724,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "total-after-gc.before": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "47d1cc41853f6cfa37db5a9c2cd7834d19ec314f",
+        "id": 1977723,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
   "webconsole-metrics.summary": {
     "platforms": {
       "linux64-opt": {
@@ -9173,6 +3434,22 @@ const PerfHerderSignatures = {
       "linux64-pgo": {
         "signature": "5f22ce0132cacc5da507d0f37187b9acd88aab54",
         "id": 1881299,
+        "old_signatures": [],
+        "framework": 12
+      }
+    }
+  },
+  "webconsole-metrics.all-modules": {
+    "platforms": {
+      "linux64-opt": {
+        "signature": "e9fd6c5f5547b5c456104b85e78d3c468dd6f8cf",
+        "id": 1881288,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "linux64-pgo": {
+        "signature": "320871399666a591ff733ea141ac51b8c00d1854",
+        "id": 1881298,
         "old_signatures": [],
         "framework": 12
       }

--- a/tools/debugger.html
+++ b/tools/debugger.html
@@ -36,6 +36,8 @@
 <iframe src="../perfherder/?test=custom.jsdebugger.stepOut"></iframe>
 <h4>Project search</h4>
 <iframe src="../perfherder/?test=custom.jsdebugger.project-search"></iframe>
+<h4>Preview</h4>
+<iframe src="../perfherder/?test=custom.jsdebugger.preview"></iframe>
 <h4>Close</h4>
 <iframe src="../perfherder/?test=custom.jsdebugger.close"></iframe>
 


### PR DESCRIPTION
This PR regenerates the perfherder signature and adds the debugger preview chart.

Small note that the signature regen commit is removing a lot of "old signature" data, as well as entries for the "settle" tests. I guess the data has been cleaned up on perfherder side, but you might want to take an extra look there.