### PR TITLE
Track linux1804-64 for metrics & memory tests

### DIFF
--- a/inspect/index.html
+++ b/inspect/index.html
@@ -22,8 +22,8 @@
   <label>New:</label><input name="new" /><br/>
   <label>Platform:</label>
     <select name="platform">
-      <option value="linux64-opt">Linux opt</option>
-      <option value="linux64-pgo">Linux pgo</option>
+      <option value="linux1804-64-opt">Linux opt</option>
+      <option value="linux1804-64-pgo">Linux pgo</option>
       <option value="windows10-64-opt">Windows 10 opt</option>
       <option value="windows10-64-pgo">Windows 10 pgo</option>
     </select><br/>
@@ -68,7 +68,7 @@ body {
     stroke-width: 1px;
 }
 
-.title 
+.title
 {
     text-anchor: middle;
     font-size: 16px;
@@ -92,29 +92,29 @@ body {
     opacity: 0.6;
 }
 
-circle 
+circle
 {
     stroke: none;
     shape-rendering: crispEdges;
 }
 
-.categoryLabel 
+.categoryLabel
 {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 0.75em;
 }
 
-.outlier 
+.outlier
 {
     opacity: 1;
 }
 
-.point 
+.point
 {
     opacity: 0.7;
 }
 
-.axis path 
+.axis path
 {
     fill: none;
     stroke: black;
@@ -122,7 +122,7 @@ circle
     shape-rendering: crispEdges;
 }
 
-.axis line 
+.axis line
 {
     fill: none;
     stroke: black;
@@ -130,23 +130,23 @@ circle
     shape-rendering: crispEdges;
 }
 
-.axis text 
+.axis text
 {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 10px;
 }
 
-div.tooltip 
-{   
-    position: absolute;         
-    text-align: center;                                              
-    padding: 3px;               
+div.tooltip
+{
+    position: absolute;
+    text-align: center;
+    padding: 3px;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 11px;      
-    background: lightsteelblue; 
-    border: 0px;        
-    border-radius: 8px;         
-    pointer-events: none;           
+    font-size: 11px;
+    background: lightsteelblue;
+    border: 0px;
+    border-radius: 8px;
+    pointer-events: none;
 }
 
 tr.even {

--- a/perfherder/perfherder-signatures.js
+++ b/perfherder/perfherder-signatures.js
@@ -1,50 +1,4 @@
 const PerfHerderSignatures = {
-  "summary": {
-    "platforms": {
-      "windows7-32-opt": {
-        "signature": "2fa549258445b035f7463afad97852e46b399a6d",
-        "id": 1760562,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "windows7-32-pgo": {
-        "signature": "389a5b1ef37772bad22611e4d6237fffea35c9cb",
-        "id": 1761212,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "windows10-64-opt": {
-        "signature": "28c4fee1ef7d4e5d184aa628df7c94de208b7678",
-        "id": 1760887,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "windows10-64-pgo": {
-        "signature": "2e2b666b2c9746ca9fe1184efc6f182c330e8398",
-        "id": 1761277,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-opt": {
-        "signature": "f79b6a4f1f8f53326d3056f6c8008c0ff4de0a94",
-        "id": 1760367,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "d0aa31b4a8617d5bda9bc8c5ca7bfa9a77c38c7c",
-        "id": 1761017,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "osx-10-10-opt": {
-        "signature": "7cbb05567f41ef34c669c6987c808f3fc1f5ef57",
-        "id": 1760757,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
   "cold.inspector.open": {
     "platforms": {
       "windows7-32-opt": {
@@ -71,17 +25,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "c3ac3ab674fc4852863176608fd2001c90e0526d",
-        "id": 1760368,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0d02b575b2ec61dc0dfb078d87699f25622d60ed",
+            "id": 1761018,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "0d02b575b2ec61dc0dfb078d87699f25622d60ed",
-        "id": 1761018,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "c3ac3ab674fc4852863176608fd2001c90e0526d",
+            "id": 1760368,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "0a182af619108c1dfad911cc05b05b37b65fd355",
@@ -105,11 +71,17 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "9574b60a37fb3a96ae5570bb05b5b813f618c509",
-        "id": 2051940,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9574b60a37fb3a96ae5570bb05b5b813f618c509",
+            "id": 2051940,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
@@ -127,11 +99,17 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "c5f0f5d0c4977687f2cb99055f8ab323c561b0aa",
-        "id": 2051942,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "c5f0f5d0c4977687f2cb99055f8ab323c561b0aa",
+            "id": 2051942,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
@@ -149,31 +127,31 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "2196e744b9d2383085bfdc9bda27edd7126b667c",
-        "id": 2051941,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2196e744b9d2383085bfdc9bda27edd7126b667c",
+            "id": 2051941,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
   "complicated.inspector.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "b7f624daa73e971e36152c16934cf9c4c9d4e8f5",
-        "id": 1760586,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "1b0081a95becbc1bb66f146747c5bbd4947c65ba",
         "id": 1761236,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "3409ce5a386eb37e4df1e0d7c7b348459197ddd5",
-        "id": 1760911,
+      "windows7-32-opt": {
+        "signature": "b7f624daa73e971e36152c16934cf9c4c9d4e8f5",
+        "id": 1760586,
         "old_signatures": [],
         "framework": 12
       },
@@ -183,17 +161,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "e6a72c92fb7f84b33b17e776756e08e6e0e8a8f9",
-        "id": 1760391,
+      "windows10-64-opt": {
+        "signature": "3409ce5a386eb37e4df1e0d7c7b348459197ddd5",
+        "id": 1760911,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "d7424265f0f927b870db2c1ded29218999d248bb",
-        "id": 1761041,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "d7424265f0f927b870db2c1ded29218999d248bb",
+            "id": 1761041,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e6a72c92fb7f84b33b17e776756e08e6e0e8a8f9",
+            "id": 1760391,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "b6c6658b10a2ad447d7c6c0eb75e56f375c516ca",
@@ -205,15 +201,15 @@ const PerfHerderSignatures = {
   },
   "complicated.inspector.open": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "2b910c2eeba6c8ddbd4ddeb3c46ab3e7bee5ad5f",
-        "id": 1760584,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "0da14803ccd551bd6c152a191ce46170451dab0f",
         "id": 1761234,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "2b910c2eeba6c8ddbd4ddeb3c46ab3e7bee5ad5f",
+        "id": 1760584,
         "old_signatures": [],
         "framework": 12
       },
@@ -229,17 +225,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "db299ac114d1f5ff89b8c0a41b27bab19f4c0c51",
-        "id": 1760389,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "db299ac114d1f5ff89b8c0a41b27bab19f4c0c51",
+            "id": 1760389,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "fb515ef3c8374463918c5947e9f91e4909aedcf8",
-        "id": 1761039,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "fb515ef3c8374463918c5947e9f91e4909aedcf8",
+            "id": 1761039,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c95aa15a753d9fb128b37349932e73413349aed9",
@@ -251,15 +259,15 @@ const PerfHerderSignatures = {
   },
   "complicated.inspector.reload": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "3d161f7ba7086b83675da84ca55ac19ba0bb9a58",
-        "id": 1760585,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "4b1c7719ec651d0c5fa7be4cde11eb5ec324dd0e",
         "id": 1761235,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "3d161f7ba7086b83675da84ca55ac19ba0bb9a58",
+        "id": 1760585,
         "old_signatures": [],
         "framework": 12
       },
@@ -275,17 +283,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "9438fe01afb26eab3d43bac8b09de5123d59ae2e",
-        "id": 1760390,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9438fe01afb26eab3d43bac8b09de5123d59ae2e",
+            "id": 1760390,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "b1bff4e07a610268bc01273c5c634d076527fee0",
-        "id": 1761040,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b1bff4e07a610268bc01273c5c634d076527fee0",
+            "id": 1761040,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "9bc5647bfce1a6f9f0603ecee39bdc77b125f611",
@@ -321,17 +341,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "01a48a65cc0406d65a648ca7777d755e3115eaee",
-        "id": 1760394,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "01a48a65cc0406d65a648ca7777d755e3115eaee",
+            "id": 1760394,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "fbbc0c5aa54c10ad34fd47b6bfa90ee4eee52500",
-        "id": 1761044,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "fbbc0c5aa54c10ad34fd47b6bfa90ee4eee52500",
+            "id": 1761044,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "ad98a19382269e4da1ec31ca4ab313e3d8785595",
@@ -367,17 +399,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "3adac34e5e1fb79c06b80625920a9b0b76b12d5f",
-        "id": 1760392,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "282645ae33d2d3025c06204da0dde0a936cd2b11",
+            "id": 1761042,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "282645ae33d2d3025c06204da0dde0a936cd2b11",
-        "id": 1761042,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "3adac34e5e1fb79c06b80625920a9b0b76b12d5f",
+            "id": 1760392,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "b48cc63f6ecdf0af242d54cc055567aabbaf4fc0",
@@ -401,29 +445,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "f9de681fc7f192f147299d9c36b61e41085b2f5b",
-        "id": 1760913,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "5bbf597daa6eebc3c417df4e3529e53b3b715b8a",
         "id": 1761303,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "63194a9fb5bf2a19af5e45b9ba507e08a68157ed",
-        "id": 1760393,
+      "windows10-64-opt": {
+        "signature": "f9de681fc7f192f147299d9c36b61e41085b2f5b",
+        "id": 1760913,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "9e325cc34e6de95e2408fbf36e3240d469b5cd93",
-        "id": 1761043,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "63194a9fb5bf2a19af5e45b9ba507e08a68157ed",
+            "id": 1760393,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9e325cc34e6de95e2408fbf36e3240d469b5cd93",
+            "id": 1761043,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "9e7dd5932b6f4680d34ec827ea4508b7df94fc4b",
@@ -435,15 +491,15 @@ const PerfHerderSignatures = {
   },
   "complicated.netmonitor.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "b3059e47ab8fd79887bc7c69cd3bf17235afb5c6",
-        "id": 1760597,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "6fcda28e2fc6eeefb137a698aa319aa588b06a78",
         "id": 1761247,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "b3059e47ab8fd79887bc7c69cd3bf17235afb5c6",
+        "id": 1760597,
         "old_signatures": [],
         "framework": 12
       },
@@ -459,17 +515,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "2de1f58d829ebf59179090a590529409ead7d207",
-        "id": 1760402,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2de1f58d829ebf59179090a590529409ead7d207",
+            "id": 1760402,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "795fd01fba0a8de4df6fe8b006d6517fe3ef110f",
-        "id": 1761052,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "795fd01fba0a8de4df6fe8b006d6517fe3ef110f",
+            "id": 1761052,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "f90859f08e2040b059a37c10d4bbfa0cc889aad0",
@@ -493,29 +561,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "ade33e40355950b8cb1501e74555e7800394b6c8",
-        "id": 1760921,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "3a11fb6aff0d978fdd048c40d99eb51ff92ad020",
         "id": 1761311,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "935faaf13b5c5cd9b78b4851804320eea67dbc1b",
-        "id": 1760401,
+      "windows10-64-opt": {
+        "signature": "ade33e40355950b8cb1501e74555e7800394b6c8",
+        "id": 1760921,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "43c7c7dcf3662fa575c4639c97e1cdd64ee7ac88",
-        "id": 1761051,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "43c7c7dcf3662fa575c4639c97e1cdd64ee7ac88",
+            "id": 1761051,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "935faaf13b5c5cd9b78b4851804320eea67dbc1b",
+            "id": 1760401,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "6a45c0ffb341d2649f724a0771b6b1308acc8825",
@@ -551,17 +631,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "a829d97a075d511bbbca238ad36f420b46bc6c2c",
-        "id": 1760398,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "7c6d23ab92b551a20f01418f0ec0658d6b169695",
+            "id": 1761048,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "7c6d23ab92b551a20f01418f0ec0658d6b169695",
-        "id": 1761048,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a829d97a075d511bbbca238ad36f420b46bc6c2c",
+            "id": 1760398,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c2ebc4e5ed81535c7c5adca2afcb0f96eea3ca72",
@@ -585,29 +677,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "4f5054ef4194c2fe8af14e7cdb8947f6bc9dd6bb",
-        "id": 1760919,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "344218eb5d4cc56c25813cae0c5411f2f961e0ee",
         "id": 1761309,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "adcab331a70cfd234d0b42c06687c3ea96cd0535",
-        "id": 1760399,
+      "windows10-64-opt": {
+        "signature": "4f5054ef4194c2fe8af14e7cdb8947f6bc9dd6bb",
+        "id": 1760919,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "4ef53cf4e3a6b2677ec4c23bf100dd7aaf996b7a",
-        "id": 1761049,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "4ef53cf4e3a6b2677ec4c23bf100dd7aaf996b7a",
+            "id": 1761049,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "adcab331a70cfd234d0b42c06687c3ea96cd0535",
+            "id": 1760399,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "913fee75317c4b51c8ad09cb36f8dcadb5adaf75",
@@ -631,29 +735,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "c0593c68649271014f173674fc2721942a1882db",
-        "id": 1760920,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "60afeb088b4b853812011e69e4422b8e3cbffe12",
         "id": 1761310,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "c5ed310296444acb3515536648fab1812527b3d1",
-        "id": 1760400,
+      "windows10-64-opt": {
+        "signature": "c0593c68649271014f173674fc2721942a1882db",
+        "id": 1760920,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "74948c0737bdf76aa962e057b47f47feede8996c",
-        "id": 1761050,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "74948c0737bdf76aa962e057b47f47feede8996c",
+            "id": 1761050,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "c5ed310296444acb3515536648fab1812527b3d1",
+            "id": 1760400,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "b6a2299f76b7f147830900315ab82b9f71581784",
@@ -677,29 +793,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "88271215eac1271235cd6d7bfcb0ac37a6008cf1",
-        "id": 1760917,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "51d4895ecf1e6ab11ef40c8bcdc697b2e5502fa2",
         "id": 1761307,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "ef9a07d9fe64dd94dd7a57a094d329defcb8a7e8",
-        "id": 1760397,
+      "windows10-64-opt": {
+        "signature": "88271215eac1271235cd6d7bfcb0ac37a6008cf1",
+        "id": 1760917,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "99f50ab4f7ca3144644c518bab47c8aaeceee9ed",
-        "id": 1761047,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "99f50ab4f7ca3144644c518bab47c8aaeceee9ed",
+            "id": 1761047,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "ef9a07d9fe64dd94dd7a57a094d329defcb8a7e8",
+            "id": 1760397,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "d06c0f2feb7169bee79607f37405f265bf051f2e",
@@ -735,17 +863,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "73d5c526dd4deb10d7e3bd01508703e75a17850b",
-        "id": 1760395,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0fb7c78277878642e9f016bf00dfc5ac64e6bcd7",
+            "id": 1761045,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "0fb7c78277878642e9f016bf00dfc5ac64e6bcd7",
-        "id": 1761045,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "73d5c526dd4deb10d7e3bd01508703e75a17850b",
+            "id": 1760395,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "39c057c5a3a4779146e0a99d145575b5180300df",
@@ -781,17 +921,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "b8b69e494f9886b00ff98143ef0fd62f25248a84",
-        "id": 1760396,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b8b69e494f9886b00ff98143ef0fd62f25248a84",
+            "id": 1760396,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "eaca97f9a79609ee2a6b0a87aa0cfaccf20f1618",
-        "id": 1761046,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "eaca97f9a79609ee2a6b0a87aa0cfaccf20f1618",
+            "id": 1761046,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "1f91027f887f3e4fc65d3388bb89d883ca3f1cd2",
@@ -803,15 +955,15 @@ const PerfHerderSignatures = {
   },
   "complicated.webconsole.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "376d56fce6598fc6e9f06a7acfa9198a2aece31f",
-        "id": 1760583,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "c4729dea54b9a8d313d5209d86536b0be1a447f3",
         "id": 1761233,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "376d56fce6598fc6e9f06a7acfa9198a2aece31f",
+        "id": 1760583,
         "old_signatures": [],
         "framework": 12
       },
@@ -827,17 +979,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "9b0bbf2ea023e080cdfd9a77e0915d2d46293b83",
-        "id": 1760388,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9b0bbf2ea023e080cdfd9a77e0915d2d46293b83",
+            "id": 1760388,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "a519a7395bc93e5c29f3cd8b8e939f0a45dfd06c",
-        "id": 1761038,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a519a7395bc93e5c29f3cd8b8e939f0a45dfd06c",
+            "id": 1761038,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "35fb1261bd1162fa1594a0a0ff80af4e81cc3027",
@@ -861,29 +1025,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "419bec5cb54e2b8081594dae3e5ff6c0b9d61309",
-        "id": 1760906,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "3adabb863066d79a923ab27f5545c039ba8b15a0",
         "id": 1761296,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "5e273b93875f10482d4ab2f6f31a3398d769bb6d",
-        "id": 1760386,
+      "windows10-64-opt": {
+        "signature": "419bec5cb54e2b8081594dae3e5ff6c0b9d61309",
+        "id": 1760906,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "6599f8b6a38145c116337212286197946ea38fcf",
-        "id": 1761036,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5e273b93875f10482d4ab2f6f31a3398d769bb6d",
+            "id": 1760386,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6599f8b6a38145c116337212286197946ea38fcf",
+            "id": 1761036,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "d64e2ac7edf41b832db83e9978470786ef8a834b",
@@ -907,29 +1083,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "88d15829227ecea9ffaca6fd7ad287e23beb9dda",
-        "id": 1760907,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "73b1cce2a5c278319a366c327d84ea19af80843e",
         "id": 1761297,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "ad373754e919e41067b2f4788b2ff9b0d88dd86f",
-        "id": 1760387,
+      "windows10-64-opt": {
+        "signature": "88d15829227ecea9ffaca6fd7ad287e23beb9dda",
+        "id": 1760907,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "06632a464fcae8eeafa6246c834acd84c43d851b",
-        "id": 1761037,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "06632a464fcae8eeafa6246c834acd84c43d851b",
+            "id": 1761037,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "ad373754e919e41067b2f4788b2ff9b0d88dd86f",
+            "id": 1760387,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "9e5f2685e8ffee8585f96fd93bfc5111f5c22cdf",
@@ -965,17 +1153,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "0278f6f740f18a96b43d0baeace4ffb0a35f064e",
-        "id": 1760423,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "00fd75c22fa18b7ff3b54a69dbdb3fbebb1b17c9",
+            "id": 1761073,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "00fd75c22fa18b7ff3b54a69dbdb3fbebb1b17c9",
-        "id": 1761073,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0278f6f740f18a96b43d0baeace4ffb0a35f064e",
+            "id": 1760423,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "de3f444654c8a1f83d20df9ad9f685bf6492d546",
@@ -999,11 +1199,17 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "8dfcfd8a8cc22c944e51c3eab6be0ed8de4f2a50",
-        "id": 2092754,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "8dfcfd8a8cc22c944e51c3eab6be0ed8de4f2a50",
+            "id": 2092754,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
@@ -1021,29 +1227,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "300288dc3bbe95c671cc51108a8bcb360768589b",
-        "id": 1760942,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "c443da532210865d5902853a62a2649ab1735ab7",
         "id": 1761332,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "e5a0446f5f248c6490695dd2d90ec608175957c9",
-        "id": 1760422,
+      "windows10-64-opt": {
+        "signature": "300288dc3bbe95c671cc51108a8bcb360768589b",
+        "id": 1760942,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "6758cecba0cf4d2b048648ee657f5c541c3c157c",
-        "id": 1761072,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e5a0446f5f248c6490695dd2d90ec608175957c9",
+            "id": 1760422,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6758cecba0cf4d2b048648ee657f5c541c3c157c",
+            "id": 1761072,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "96f15af34024a9373cec4cc03a6aaf8a00ed8ad2",
@@ -1055,21 +1273,15 @@ const PerfHerderSignatures = {
   },
   "console.objectexpand": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "cecba81df61dff9fda652dbb1a77326e507cfcd5",
-        "id": 1760620,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "4ee3029bb70e429a064e7788c8b845b1a116248f",
         "id": 1761270,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "28c867a96d2e41cb3428c096f569e9d2089391df",
-        "id": 1760945,
+      "windows7-32-opt": {
+        "signature": "cecba81df61dff9fda652dbb1a77326e507cfcd5",
+        "id": 1760620,
         "old_signatures": [],
         "framework": 12
       },
@@ -1079,17 +1291,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "31f7776cd76a6058f6dbf380be3dcecf650a8c0b",
-        "id": 1760425,
+      "windows10-64-opt": {
+        "signature": "28c867a96d2e41cb3428c096f569e9d2089391df",
+        "id": 1760945,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "a1a748e1c38d2a9d01c07091fe5a2f59ee4f30c0",
-        "id": 1761075,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "31f7776cd76a6058f6dbf380be3dcecf650a8c0b",
+            "id": 1760425,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a1a748e1c38d2a9d01c07091fe5a2f59ee4f30c0",
+            "id": 1761075,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "9febe43c04703458dfcbd7df1d22ff25900b3798",
@@ -1101,15 +1331,15 @@ const PerfHerderSignatures = {
   },
   "console.objectexpanded.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "bc1cf0fe5ecf781af339b2739ed483e3a3be3d80",
-        "id": 1760621,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "570e06c012b8ffe1c7fc217357972cd9ce28c277",
         "id": 1761271,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "bc1cf0fe5ecf781af339b2739ed483e3a3be3d80",
+        "id": 1760621,
         "old_signatures": [],
         "framework": 12
       },
@@ -1125,17 +1355,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "b0e8f4dcb75883dffceee221f35c044274d3c624",
-        "id": 1760426,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6d413bcc545817d29d997e573ab5be08edd85080",
+            "id": 1761076,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "6d413bcc545817d29d997e573ab5be08edd85080",
-        "id": 1761076,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b0e8f4dcb75883dffceee221f35c044274d3c624",
+            "id": 1760426,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "38712d8025e02f8a319f84a7218b5596d21ebbe9",
@@ -1159,29 +1401,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "1ed55698ceaaea75966410c0fbbd3c67f6cc13d4",
-        "id": 1760947,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "0ea965fe139ba245e3b01c69047cb741d4f6115d",
         "id": 1761337,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "b12966be150fb8d180683c9994b95b7b41717d8b",
-        "id": 1760427,
+      "windows10-64-opt": {
+        "signature": "1ed55698ceaaea75966410c0fbbd3c67f6cc13d4",
+        "id": 1760947,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "864fbb1e6873ac43507c0cf27e75bf752600bcbe",
-        "id": 1761077,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "864fbb1e6873ac43507c0cf27e75bf752600bcbe",
+            "id": 1761077,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b12966be150fb8d180683c9994b95b7b41717d8b",
+            "id": 1760427,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "5fe65e2ffc0a9119dbe0e917cf8d1a7d8609fcb7",
@@ -1193,15 +1447,15 @@ const PerfHerderSignatures = {
   },
   "console.streamlog": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "ac8ed43934946b4dbe8c04e69c09a3faf0a7c868",
-        "id": 1760619,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "a4f43672d6a58f09e58e5767061132d84291ca81",
         "id": 1761269,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "ac8ed43934946b4dbe8c04e69c09a3faf0a7c868",
+        "id": 1760619,
         "old_signatures": [],
         "framework": 12
       },
@@ -1217,17 +1471,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "95ca6e2f4bb93a07e52f3b5daa236570578e3e3a",
-        "id": 1760424,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "10beb945872afdd821b499d58d7f9209ca60bb4b",
+            "id": 1761074,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "10beb945872afdd821b499d58d7f9209ca60bb4b",
-        "id": 1761074,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "95ca6e2f4bb93a07e52f3b5daa236570578e3e3a",
+            "id": 1760424,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "fd76c8c981e076287bcbcdf1f96809f16287c022",
@@ -1263,17 +1529,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "175bfc3b9870373f8aa805b7dd0165dfa19aeed5",
-        "id": 1779162,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "175bfc3b9870373f8aa805b7dd0165dfa19aeed5",
+            "id": 1779162,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "39f4d549d0ba11aa5bdc6b29057cf66b77fd4571",
-        "id": 1779167,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "39f4d549d0ba11aa5bdc6b29057cf66b77fd4571",
+            "id": 1779167,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "43c42722da046593973d6c72e831814c87f79b27",
@@ -1309,17 +1587,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "ed44b53b68761edace9fc54831c6b3b2e99da789",
-        "id": 1760414,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "17a82fb0c17f471ea24b26ee68c3673cccffefcd",
+            "id": 1761064,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "17a82fb0c17f471ea24b26ee68c3673cccffefcd",
-        "id": 1761064,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "ed44b53b68761edace9fc54831c6b3b2e99da789",
+            "id": 1760414,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "f26b405b7a4eb657aeb031830eeb4b7b53228355",
@@ -1331,15 +1621,15 @@ const PerfHerderSignatures = {
   },
   "custom.inspector.collapseall.balanced": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "b57d746f0ca2222590ab1930e2dbef650e08c4d2",
-        "id": 1760608,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "12955855421820c74bcfca3d964fdb277a5786dc",
         "id": 1761258,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "b57d746f0ca2222590ab1930e2dbef650e08c4d2",
+        "id": 1760608,
         "old_signatures": [],
         "framework": 12
       },
@@ -1355,17 +1645,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "e4e2177920f02792673589b094f5ed7b1f535a96",
-        "id": 1760413,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "18dedca3c3f19d8eb61403aabd4229d491efa002",
+            "id": 1761063,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "18dedca3c3f19d8eb61403aabd4229d491efa002",
-        "id": 1761063,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e4e2177920f02792673589b094f5ed7b1f535a96",
+            "id": 1760413,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "a51d40db8d43b1975d39e1e608f1fd6bb21957fc",
@@ -1401,17 +1703,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "62e13ef684cef1c52c89cc41c5da390c763aa653",
-        "id": 1760411,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "62e13ef684cef1c52c89cc41c5da390c763aa653",
+            "id": 1760411,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "69a9919c36605c29cd235284e7871318322e265b",
-        "id": 1761061,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "69a9919c36605c29cd235284e7871318322e265b",
+            "id": 1761061,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "47a0e46ce8f85d7dd972fd591206d25c603081d7",
@@ -1423,15 +1737,15 @@ const PerfHerderSignatures = {
   },
   "custom.inspector.expandall.balanced": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "ead7726d0d2b0e35baa721a2ff8252a053d483f5",
-        "id": 1760607,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "973b5d4e5868961b43bec0d6533eddd9ed9b3afa",
         "id": 1761257,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "ead7726d0d2b0e35baa721a2ff8252a053d483f5",
+        "id": 1760607,
         "old_signatures": [],
         "framework": 12
       },
@@ -1447,17 +1761,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "071c79a5c33da0e3147318bc69a60eaaa9d1aaff",
-        "id": 1760412,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "071c79a5c33da0e3147318bc69a60eaaa9d1aaff",
+            "id": 1760412,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "a36450bf9e4fcd440681d7641f845836ff2d4dad",
-        "id": 1761062,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a36450bf9e4fcd440681d7641f845836ff2d4dad",
+            "id": 1761062,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "7b6601f7e21f7c63f5f44267c029bb19fcae7c63",
@@ -1469,15 +1795,15 @@ const PerfHerderSignatures = {
   },
   "custom.inspector.expandall.manychildren": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "c0f0a0819480c48a5c16fe16d4744d34b8a7e068",
-        "id": 1760605,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "03ab439d3b745f3bf5145f9c79ff68b27ff94ee3",
         "id": 1761255,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "c0f0a0819480c48a5c16fe16d4744d34b8a7e068",
+        "id": 1760605,
         "old_signatures": [],
         "framework": 12
       },
@@ -1493,17 +1819,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "2827dd590756caff04628f65c6f15710fce569c7",
-        "id": 1760410,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2827dd590756caff04628f65c6f15710fce569c7",
+            "id": 1760410,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "41b372283739b2fc36406400f7fe01d9aa86377e",
-        "id": 1761060,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "41b372283739b2fc36406400f7fe01d9aa86377e",
+            "id": 1761060,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "4c8d1e397c97df7847e5eaa2305b4f664d6eca17",
@@ -1539,17 +1877,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "308a29c813bc4f09b131fffcd0c6d1d1f55b5470",
-        "id": 1760409,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2517f1804caaa7aaffce8534231c537dfeb04035",
+            "id": 1761059,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "2517f1804caaa7aaffce8534231c537dfeb04035",
-        "id": 1761059,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "308a29c813bc4f09b131fffcd0c6d1d1f55b5470",
+            "id": 1760409,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "97513decb49751b7d81c8a94fc3e6fdb78a6b448",
@@ -1573,29 +1923,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "d02c62355f6fc106ac79ed925355c14cdc7ca519",
-        "id": 1760928,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "68613286e9e4ca5056945dc77854c09404522c7f",
         "id": 1761318,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "e461295da6e3d4a6fa60edf4fb0204d3dba0d84f",
-        "id": 1760408,
+      "windows10-64-opt": {
+        "signature": "d02c62355f6fc106ac79ed925355c14cdc7ca519",
+        "id": 1760928,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "cfd2d45ccfc1d43d4373cb1f47ad8b0f51542d30",
-        "id": 1761058,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e461295da6e3d4a6fa60edf4fb0204d3dba0d84f",
+            "id": 1760408,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "cfd2d45ccfc1d43d4373cb1f47ad8b0f51542d30",
+            "id": 1761058,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "639c7b7bbe1683b63c3cbb6267a1e2e6dfe9a661",
@@ -1619,29 +1981,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "c6ac5b2ac017145f39af01cf9f5b6008aae3bd60",
-        "id": 1760926,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "5e8338139d7426ca57a1ee813b896612c79e1c56",
         "id": 1761316,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "7dc6817d8889e93e5281bd863517e28d9a56e6fb",
-        "id": 1760406,
+      "windows10-64-opt": {
+        "signature": "c6ac5b2ac017145f39af01cf9f5b6008aae3bd60",
+        "id": 1760926,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "a8b03818ef1c4b1982fe113a82293360b7028c34",
-        "id": 1761056,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "7dc6817d8889e93e5281bd863517e28d9a56e6fb",
+            "id": 1760406,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a8b03818ef1c4b1982fe113a82293360b7028c34",
+            "id": 1761056,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "71d1a05de4ef30977ed9dd55f8e46d4dc4afc9a6",
@@ -1677,17 +2051,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "a27dbdaed8b47209a1f1d2e8f42b6a794dde29d7",
-        "id": 1760407,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6faa35709ca9fff83216ad70671b459aed2ec31b",
+            "id": 1761057,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "6faa35709ca9fff83216ad70671b459aed2ec31b",
-        "id": 1761057,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a27dbdaed8b47209a1f1d2e8f42b6a794dde29d7",
+            "id": 1760407,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "31f6e406245c03b97f99c86fd3533afbfa888b84",
@@ -1723,17 +2109,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "2a1c95b7ff355ebcd18141cb6ac26f6307fdf99d",
-        "id": 1760421,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "10ccff7b55a48330a284d85766c0cb11e927ce4e",
+            "id": 1761071,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "10ccff7b55a48330a284d85766c0cb11e927ce4e",
-        "id": 1761071,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2a1c95b7ff355ebcd18141cb6ac26f6307fdf99d",
+            "id": 1760421,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c8691e770ccef615f796f5009ae64d103d69ba60",
@@ -1757,29 +2155,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "8451f14751ff89f9bfd4dae7390dab99088bd3d3",
-        "id": 1760935,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "55981f370d210fa549f9befaf8100a77ece9d2fc",
         "id": 1761325,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "942e6714fc1a5624cc063d7d13f60414f813c7d7",
-        "id": 1760415,
+      "windows10-64-opt": {
+        "signature": "8451f14751ff89f9bfd4dae7390dab99088bd3d3",
+        "id": 1760935,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "d8327d95e558a79bc1a61b3764ca25ae6ad7930a",
-        "id": 1761065,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "942e6714fc1a5624cc063d7d13f60414f813c7d7",
+            "id": 1760415,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "d8327d95e558a79bc1a61b3764ca25ae6ad7930a",
+            "id": 1761065,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "af243d74450bfd10967613c35a1245b76ea259a0",
@@ -1791,21 +2201,15 @@ const PerfHerderSignatures = {
   },
   "custom.jsdebugger.pause": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "e48a906ff2548551b585549bed8e40be1cda3e74",
-        "id": 1760612,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "a27a8f62b9e2cf72655922425ff202c7a96f5bab",
         "id": 1761262,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "d70b820ddf74cdd6a200fcdc629f0af14235a092",
-        "id": 1760937,
+      "windows7-32-opt": {
+        "signature": "e48a906ff2548551b585549bed8e40be1cda3e74",
+        "id": 1760612,
         "old_signatures": [],
         "framework": 12
       },
@@ -1815,17 +2219,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "13ba4fa720daf00b66320cf315715dba2e53b429",
-        "id": 1760417,
+      "windows10-64-opt": {
+        "signature": "d70b820ddf74cdd6a200fcdc629f0af14235a092",
+        "id": 1760937,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "24c7ab697210e88a75a042ef83ac1f3715d53671",
-        "id": 1761067,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "13ba4fa720daf00b66320cf315715dba2e53b429",
+            "id": 1760417,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "24c7ab697210e88a75a042ef83ac1f3715d53671",
+            "id": 1761067,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "6d3c8f80d852a331471c4d1190d8680e5712909b",
@@ -1849,11 +2271,17 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "5cf97a000f6be3bed97502bfcaa29a42832367a5",
-        "id": 2059415,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5cf97a000f6be3bed97502bfcaa29a42832367a5",
+            "id": 2059415,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
@@ -1871,31 +2299,31 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "22a6c238b4e701ad53084d27861eef49084b6c48",
-        "id": 2011310,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "22a6c238b4e701ad53084d27861eef49084b6c48",
+            "id": 2011310,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
   "custom.jsdebugger.reload": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "fb540659f1d9a7756497e3a0d065f94cb8df5dd9",
-        "id": 1760611,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "0a447de6a33dcf44fe3a2f591cf5c068fb385c9f",
         "id": 1761261,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "6aa96350c4283bbf6bee1c07e7e883bedf692d2b",
-        "id": 1760936,
+      "windows7-32-opt": {
+        "signature": "fb540659f1d9a7756497e3a0d065f94cb8df5dd9",
+        "id": 1760611,
         "old_signatures": [],
         "framework": 12
       },
@@ -1905,17 +2333,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "f1b40e9f78c8b76b92848f248c77f49b5869b9c4",
-        "id": 1760416,
+      "windows10-64-opt": {
+        "signature": "6aa96350c4283bbf6bee1c07e7e883bedf692d2b",
+        "id": 1760936,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "bd75fee9d559b0a31f8831b2a505ff39f61cd11d",
-        "id": 1761066,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "bd75fee9d559b0a31f8831b2a505ff39f61cd11d",
+            "id": 1761066,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f1b40e9f78c8b76b92848f248c77f49b5869b9c4",
+            "id": 1760416,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "7b75275679060c11bfce7d545736bd56bc5e07f9",
@@ -1927,21 +2373,15 @@ const PerfHerderSignatures = {
   },
   "custom.jsdebugger.stepIn": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "f92b95e4f9362de27534dc069cd5db59ea5561e7",
-        "id": 1760613,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "11329565da785675a2f801d7379959835c04c2ee",
         "id": 1761263,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "81e530ca2fd10dbca8344a759bc9c86dfcb2ca6a",
-        "id": 1760938,
+      "windows7-32-opt": {
+        "signature": "f92b95e4f9362de27534dc069cd5db59ea5561e7",
+        "id": 1760613,
         "old_signatures": [],
         "framework": 12
       },
@@ -1951,17 +2391,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "6f37c3ba3eb01e234e2dbc9c3d02544346d083cd",
-        "id": 1760418,
+      "windows10-64-opt": {
+        "signature": "81e530ca2fd10dbca8344a759bc9c86dfcb2ca6a",
+        "id": 1760938,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "e5beaac2183892fd1032edaddecc71296e0c7f39",
-        "id": 1761068,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6f37c3ba3eb01e234e2dbc9c3d02544346d083cd",
+            "id": 1760418,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e5beaac2183892fd1032edaddecc71296e0c7f39",
+            "id": 1761068,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "d5370df8b258789dbb58bfe87c2878ad676c21ff",
@@ -1997,17 +2455,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "9c53e48144fe27b59dfe5796879988bab7bb0d26",
-        "id": 1760420,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "543a46b650daf6bc46b0c58c2e69e7170717a636",
+            "id": 1761070,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "543a46b650daf6bc46b0c58c2e69e7170717a636",
-        "id": 1761070,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9c53e48144fe27b59dfe5796879988bab7bb0d26",
+            "id": 1760420,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "10f7fe3fa3236851ca5f3df6cbedd7a3d2b63336",
@@ -2019,15 +2489,15 @@ const PerfHerderSignatures = {
   },
   "custom.jsdebugger.stepOver": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "c9dec1559d576adadd067d0038e278084e65fb74",
-        "id": 1760614,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "500de38f0c32164d135236482e55e592bdfd2933",
         "id": 1761264,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "c9dec1559d576adadd067d0038e278084e65fb74",
+        "id": 1760614,
         "old_signatures": [],
         "framework": 12
       },
@@ -2043,17 +2513,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "cfed29cc140fd4f23bcfb20a15644fee011e3ad3",
-        "id": 1760419,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2240cbe0958e108060710feb082d072a890c1ab4",
+            "id": 1761069,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "2240cbe0958e108060710feb082d072a890c1ab4",
-        "id": 1761069,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "cfed29cc140fd4f23bcfb20a15644fee011e3ad3",
+            "id": 1760419,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "469af9d987e60ae6abee4cb583c6e1ad543db1ae",
@@ -2065,15 +2547,15 @@ const PerfHerderSignatures = {
   },
   "custom.webconsole.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "de570931bda5b3f2fc7daf9b4ce6baf8cf00dbbc",
-        "id": 1760600,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "bf7767e55ad2c96fcffb2cb3fbcc58abf284282f",
         "id": 1761250,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "de570931bda5b3f2fc7daf9b4ce6baf8cf00dbbc",
+        "id": 1760600,
         "old_signatures": [],
         "framework": 12
       },
@@ -2089,17 +2571,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "f93a80d8632e2d8ef36c011edf4f38a9b66af0d4",
-        "id": 1760405,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "8f98334178a5ca3c8f912f0178b45b0ef78deae0",
+            "id": 1761055,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "8f98334178a5ca3c8f912f0178b45b0ef78deae0",
-        "id": 1761055,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f93a80d8632e2d8ef36c011edf4f38a9b66af0d4",
+            "id": 1760405,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "2499e81e179a1cc4fde187fcd6af64679258ded7",
@@ -2135,17 +2629,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "99a80e257b1cf8839c630f5250f4d4ac74d4d59f",
-        "id": 1760403,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5a84815bd324703c235b20c58e8f9eb1471e4046",
+            "id": 1761053,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "5a84815bd324703c235b20c58e8f9eb1471e4046",
-        "id": 1761053,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "99a80e257b1cf8839c630f5250f4d4ac74d4d59f",
+            "id": 1760403,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "f3f8c68fefcc7bda160f98a6253ce5bf64e96ffa",
@@ -2157,15 +2663,15 @@ const PerfHerderSignatures = {
   },
   "custom.webconsole.reload": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "dd0ec03f6fc8802f0e867adc5c1b7d72712e9894",
-        "id": 1760599,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "667a34afb9dd6d45d2f242bf70a5b6126498e0c2",
         "id": 1761249,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "dd0ec03f6fc8802f0e867adc5c1b7d72712e9894",
+        "id": 1760599,
         "old_signatures": [],
         "framework": 12
       },
@@ -2181,17 +2687,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "3778a98abbae34fdbafdec03e60695781ef17435",
-        "id": 1760404,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "3778a98abbae34fdbafdec03e60695781ef17435",
+            "id": 1760404,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "87429c5a2a213871be4e16fda9376f1a1dbba460",
-        "id": 1761054,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "87429c5a2a213871be4e16fda9376f1a1dbba460",
+            "id": 1761054,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "668fb8521d744313f7c0dabd4dcfc97a524dbed2",
@@ -2215,29 +2733,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "f2d2a071cbd04dd81844f8425f9fb5361e432914",
-        "id": 1760949,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "52407dacbab0cffaec1b6ff4984de214b7de4fa5",
         "id": 1761339,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "4af1b4a7b1b849070343ed8898b9b9f3a242d73e",
-        "id": 1760429,
+      "windows10-64-opt": {
+        "signature": "f2d2a071cbd04dd81844f8425f9fb5361e432914",
+        "id": 1760949,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "e32b8c386fcdd8ed909e03ab1e343002899f3ddf",
-        "id": 1761079,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e32b8c386fcdd8ed909e03ab1e343002899f3ddf",
+            "id": 1761079,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "4af1b4a7b1b849070343ed8898b9b9f3a242d73e",
+            "id": 1760429,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c5b9b4c80b5b724b26da361bbf837359b0ebb960",
@@ -2273,17 +2803,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "4b210e20bf8cbd9568e99e3933cf925fb443f89c",
-        "id": 1760428,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "4b210e20bf8cbd9568e99e3933cf925fb443f89c",
+            "id": 1760428,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "b648df19bf6c7a83af87767704202cc33a93a0a6",
-        "id": 1761078,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b648df19bf6c7a83af87767704202cc33a93a0a6",
+            "id": 1761078,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "d75ae880132f86a937df1006d4af324e1dc11d78",
@@ -2307,29 +2849,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "8f98c6f33053cc8ca8227a6207912049e5fa1cd4",
-        "id": 1760950,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "7586bb0df3c97189be0baed252011a8c453e234f",
         "id": 1761340,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "8162e49bb18dc47ca6862d045aa19b219dd7d5fa",
-        "id": 1760430,
+      "windows10-64-opt": {
+        "signature": "8f98c6f33053cc8ca8227a6207912049e5fa1cd4",
+        "id": 1760950,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "0708696dd176b6f11563b761bdff11e1912ce648",
-        "id": 1761080,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0708696dd176b6f11563b761bdff11e1912ce648",
+            "id": 1761080,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "8162e49bb18dc47ca6862d045aa19b219dd7d5fa",
+            "id": 1760430,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "e00737a6dae5ec76d12186cd6025188ab19c1c1d",
@@ -2365,17 +2919,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "1fb5e5aa6e50348e1828f40f1f4a2185d3db2bd8",
-        "id": 1760431,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "1bd628cffa7f4fa51e901a9963c842f26ff8c2ac",
+            "id": 1761081,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "1bd628cffa7f4fa51e901a9963c842f26ff8c2ac",
-        "id": 1761081,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "1fb5e5aa6e50348e1828f40f1f4a2185d3db2bd8",
+            "id": 1760431,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "2ea6549d4878c56feaa86f8c77df71f1006dfec7",
@@ -2399,29 +2965,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "daefed59599f269eb7224ad2227a70209eeb9da1",
-        "id": 1760894,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "95133f33af911ff05bcae6bdd3fc88cbd55d0f61",
         "id": 1761284,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "c58b0e57d17065d3942c02832ce506139de4f2f2",
-        "id": 1760374,
+      "windows10-64-opt": {
+        "signature": "daefed59599f269eb7224ad2227a70209eeb9da1",
+        "id": 1760894,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "73501b03fa397cf32478b5674307a409c1ae5870",
-        "id": 1761024,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "73501b03fa397cf32478b5674307a409c1ae5870",
+            "id": 1761024,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "c58b0e57d17065d3942c02832ce506139de4f2f2",
+            "id": 1760374,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "ae4719494e30ad2f95e969aa5656dba7fbce3aa2",
@@ -2457,17 +3035,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "bc8539457aa768b118a8a2e4dbff1e346d92dade",
-        "id": 1760372,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "bc8539457aa768b118a8a2e4dbff1e346d92dade",
+            "id": 1760372,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "ca95ae244d5cb2ce60290a4ed4483696ab7ba77b",
-        "id": 1761022,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "ca95ae244d5cb2ce60290a4ed4483696ab7ba77b",
+            "id": 1761022,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c435d1a12ac4b93c534158338810432761286e8f",
@@ -2479,21 +3069,15 @@ const PerfHerderSignatures = {
   },
   "simple.inspector.reload": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "ad9afa3a6506c4e179ab9461e7c6a2b9903601db",
-        "id": 1760568,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "41bb89820ac47c34f35c6e9e5d0547a9b67f21d7",
         "id": 1761218,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "c26142c1316ecd45e3b5ee906f64fea6e7efdc48",
-        "id": 1760893,
+      "windows7-32-opt": {
+        "signature": "ad9afa3a6506c4e179ab9461e7c6a2b9903601db",
+        "id": 1760568,
         "old_signatures": [],
         "framework": 12
       },
@@ -2503,17 +3087,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "3d83793788276d9cc299561ccfbc3ce9efa5114e",
-        "id": 1760373,
+      "windows10-64-opt": {
+        "signature": "c26142c1316ecd45e3b5ee906f64fea6e7efdc48",
+        "id": 1760893,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "adcabd1022c892de196394d3cbb3b1fd7aea7132",
-        "id": 1761023,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "3d83793788276d9cc299561ccfbc3ce9efa5114e",
+            "id": 1760373,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "adcabd1022c892de196394d3cbb3b1fd7aea7132",
+            "id": 1761023,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "5409501a21691be43068e3ff527b67adc814b570",
@@ -2525,15 +3127,15 @@ const PerfHerderSignatures = {
   },
   "simple.jsdebugger.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "f3609c9a3864643e5d02786d92bf22b933c21efa",
-        "id": 1760572,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "d9a552c0421c44062e5e36b9ce1bce81e424257c",
         "id": 1761222,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "f3609c9a3864643e5d02786d92bf22b933c21efa",
+        "id": 1760572,
         "old_signatures": [],
         "framework": 12
       },
@@ -2549,17 +3151,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "0772629b333a4d11f67ac9ff09876e7d61b23630",
-        "id": 1760377,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0772629b333a4d11f67ac9ff09876e7d61b23630",
+            "id": 1760377,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "6fe2ae7ff141fc3e61dc0bac5a31f0972bb10c1a",
-        "id": 1761027,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "6fe2ae7ff141fc3e61dc0bac5a31f0972bb10c1a",
+            "id": 1761027,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "5fe189232f6fe96019285ca835298dc5f25cdda1",
@@ -2571,15 +3185,15 @@ const PerfHerderSignatures = {
   },
   "simple.jsdebugger.open": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "ee3145b583b49bf87c33ada0920f580c374c8164",
-        "id": 1760570,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "92183d723c04bdb024432abf4a4145897067174b",
         "id": 1761220,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "ee3145b583b49bf87c33ada0920f580c374c8164",
+        "id": 1760570,
         "old_signatures": [],
         "framework": 12
       },
@@ -2595,17 +3209,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "123d54019780bc67dbce5049094f2825fa50538e",
-        "id": 1760375,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "123d54019780bc67dbce5049094f2825fa50538e",
+            "id": 1760375,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "f5a396d11d2ed70d491fb66c2a25422f73e013ba",
-        "id": 1761025,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f5a396d11d2ed70d491fb66c2a25422f73e013ba",
+            "id": 1761025,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "568c76c45861816474ec9189f228cea4ecf70b8c",
@@ -2629,29 +3255,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "e553784931a7197054437e3d953800d232a02211",
-        "id": 1760896,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "d8f8a22496e0f33df07a59d59493076d02c2a1a3",
         "id": 1761286,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "666064acda23e09aa5621f108af35f3a4a4bb86f",
-        "id": 1760376,
+      "windows10-64-opt": {
+        "signature": "e553784931a7197054437e3d953800d232a02211",
+        "id": 1760896,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "8f91ee78fec525dac6cba8dda0cb1d43da0f0533",
-        "id": 1761026,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "8f91ee78fec525dac6cba8dda0cb1d43da0f0533",
+            "id": 1761026,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "666064acda23e09aa5621f108af35f3a4a4bb86f",
+            "id": 1760376,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "f57471809fe0b81b9579144685a086e3413e7832",
@@ -2675,29 +3313,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "b4a6aae029c50ae1d368997b8f370b8c7ea427b9",
-        "id": 1760905,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "1c6814d6aa3a004180da1561afc7c630a982b045",
         "id": 1761295,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "9014a728694eccc964d3970302d51284836a40b9",
-        "id": 1760385,
+      "windows10-64-opt": {
+        "signature": "b4a6aae029c50ae1d368997b8f370b8c7ea427b9",
+        "id": 1760905,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "2340996ddd23fcb9f9cfd1008a8788ecc16fab71",
-        "id": 1761035,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2340996ddd23fcb9f9cfd1008a8788ecc16fab71",
+            "id": 1761035,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9014a728694eccc964d3970302d51284836a40b9",
+            "id": 1760385,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "bf98a3f0053a704e76e964294442e7dbbdd6c920",
@@ -2709,15 +3359,15 @@ const PerfHerderSignatures = {
   },
   "simple.netmonitor.exportHar": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "f347c1da87ca1dade790d09d9f00240848b884e2",
-        "id": 1760579,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "79eedd8a6bdc11e86fc50014139c4ea56c830488",
         "id": 1761229,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "f347c1da87ca1dade790d09d9f00240848b884e2",
+        "id": 1760579,
         "old_signatures": [],
         "framework": 12
       },
@@ -2733,17 +3383,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "a50a1b74726116f2aa2a172e3ca5ba80fe0b84fe",
-        "id": 1760384,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "a50a1b74726116f2aa2a172e3ca5ba80fe0b84fe",
+            "id": 1760384,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "faee2a830f1c981d8bb9a28ce1e5035e91e7945e",
-        "id": 1761034,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "faee2a830f1c981d8bb9a28ce1e5035e91e7945e",
+            "id": 1761034,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "17667fc06d5f845a595b32ae577418cceb4d99ab",
@@ -2779,17 +3441,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "5f56b8f5aea9e2205c7f96b64b0ebed5830bd6ad",
-        "id": 1760381,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5f56b8f5aea9e2205c7f96b64b0ebed5830bd6ad",
+            "id": 1760381,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "cb255a6e0f8c68eed956c07f28031bd957a8745a",
-        "id": 1761031,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "cb255a6e0f8c68eed956c07f28031bd957a8745a",
+            "id": 1761031,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "286d1e71a9796afffeea68e70bc2609008ba4699",
@@ -2801,15 +3475,15 @@ const PerfHerderSignatures = {
   },
   "simple.netmonitor.reload": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "37617f2f9d2050085cdb0cab634db2d7e77d5860",
-        "id": 1760577,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "683e2f57d0a42066bd27546f2ca17ea2c99e46bb",
         "id": 1761227,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "37617f2f9d2050085cdb0cab634db2d7e77d5860",
+        "id": 1760577,
         "old_signatures": [],
         "framework": 12
       },
@@ -2825,17 +3499,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "fa1e4630d16647657f02322e3a8ed2f251bdb221",
-        "id": 1760382,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b0f89327264df8c56a4d7644d96ffd16ac86646f",
+            "id": 1761032,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "b0f89327264df8c56a4d7644d96ffd16ac86646f",
-        "id": 1761032,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "fa1e4630d16647657f02322e3a8ed2f251bdb221",
+            "id": 1760382,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "2163754a1c87312ed1f7b6e91fdd5f524a69274e",
@@ -2847,21 +3533,15 @@ const PerfHerderSignatures = {
   },
   "simple.netmonitor.requestsFinished": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "8da863a108a8b0f3f5ae6f4e33c6df51333477fc",
-        "id": 1760578,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "1f79cb16d1059f50aa8d49d3be5df44935a13ff2",
         "id": 1761228,
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "a0888da203ddb5389c1f2d7444eebbb21a9144e3",
-        "id": 1760903,
+      "windows7-32-opt": {
+        "signature": "8da863a108a8b0f3f5ae6f4e33c6df51333477fc",
+        "id": 1760578,
         "old_signatures": [],
         "framework": 12
       },
@@ -2871,17 +3551,35 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "b7f49c9ff6cab97aa6a4cb7265dfcf9c166486da",
-        "id": 1760383,
+      "windows10-64-opt": {
+        "signature": "a0888da203ddb5389c1f2d7444eebbb21a9144e3",
+        "id": 1760903,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "304ba05bb95c2252aae085bfd3abdf2852e72dbe",
-        "id": 1761033,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "304ba05bb95c2252aae085bfd3abdf2852e72dbe",
+            "id": 1761033,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b7f49c9ff6cab97aa6a4cb7265dfcf9c166486da",
+            "id": 1760383,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "31062f64ce2e8917d5f2db7cbb4a5d7dffbd795e",
@@ -2905,29 +3603,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "4f938be09669a3b5123f07bcd787b2b835798c0c",
-        "id": 1760900,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "478e510f574ba909364222699bacbeb3e7aeb887",
         "id": 1761290,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "db84cdb28d841c06b61f0aa9e31a2f4ed62b33b1",
-        "id": 1760380,
+      "windows10-64-opt": {
+        "signature": "4f938be09669a3b5123f07bcd787b2b835798c0c",
+        "id": 1760900,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "e2b158e250dff45d4c1a34fc1937d85921313209",
-        "id": 1761030,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "db84cdb28d841c06b61f0aa9e31a2f4ed62b33b1",
+            "id": 1760380,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "e2b158e250dff45d4c1a34fc1937d85921313209",
+            "id": 1761030,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "f9351c8ead36b8fd0f686fbd07a5a6efae37214d",
@@ -2939,15 +3649,15 @@ const PerfHerderSignatures = {
   },
   "simple.styleeditor.open": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "73fc57e0ce3afe84a5baddfb47959b89d4bb04b0",
-        "id": 1760573,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "662431ffcd444d4b8ac9a95466c40ea35ccc7414",
         "id": 1761223,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "73fc57e0ce3afe84a5baddfb47959b89d4bb04b0",
+        "id": 1760573,
         "old_signatures": [],
         "framework": 12
       },
@@ -2963,17 +3673,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "3c05bd1c548b096dd124ebe22ab3220c645fa8f2",
-        "id": 1760378,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "3c05bd1c548b096dd124ebe22ab3220c645fa8f2",
+            "id": 1760378,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "943d6cee94e32bbe1acad6bcb551dd96f73ecace",
-        "id": 1761028,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "943d6cee94e32bbe1acad6bcb551dd96f73ecace",
+            "id": 1761028,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "c8a4cd477190d744aa4012aef16f9ba3c7c82914",
@@ -3009,17 +3731,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "1f9ce1f3fd3947b0277bf15accc4c88ef42ac7ed",
-        "id": 1760379,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "1f9ce1f3fd3947b0277bf15accc4c88ef42ac7ed",
+            "id": 1760379,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "716d2df9050a1dafd217dd6bda5571b7bc0f02cc",
-        "id": 1761029,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "716d2df9050a1dafd217dd6bda5571b7bc0f02cc",
+            "id": 1761029,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "33c6617e6400d9e57bbe137918d5fb33dce228ed",
@@ -3031,15 +3765,15 @@ const PerfHerderSignatures = {
   },
   "simple.webconsole.close": {
     "platforms": {
-      "windows7-32-opt": {
-        "signature": "819f632c28e95f89759de375e0bf9748864f11eb",
-        "id": 1760566,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows7-32-pgo": {
         "signature": "60a46b9840745efa472379e4c926eb2e597ab3cb",
         "id": 1761216,
+        "old_signatures": [],
+        "framework": 12
+      },
+      "windows7-32-opt": {
+        "signature": "819f632c28e95f89759de375e0bf9748864f11eb",
+        "id": 1760566,
         "old_signatures": [],
         "framework": 12
       },
@@ -3055,17 +3789,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "daf4bee26ef109d4d85771ec94bee788008b1ef4",
-        "id": 1760371,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "daf4bee26ef109d4d85771ec94bee788008b1ef4",
+            "id": 1760371,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "f3e25d146d6eb998cd21e5615bc714cd2bd0373a",
-        "id": 1761021,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f3e25d146d6eb998cd21e5615bc714cd2bd0373a",
+            "id": 1761021,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "27ba91ae3022df6d496e6bd643c8524f30dc7ecc",
@@ -3089,29 +3835,41 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "windows10-64-opt": {
-        "signature": "e34293918e646aa4eca1861270a1aea8955e79bb",
-        "id": 1760889,
-        "old_signatures": [],
-        "framework": 12
-      },
       "windows10-64-pgo": {
         "signature": "17c2cc2d5de8f57b7f851659acf6cb33aa23b294",
         "id": 1761279,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "95977e687acc3477da68170f1279f2999d73c0d9",
-        "id": 1760369,
+      "windows10-64-opt": {
+        "signature": "e34293918e646aa4eca1861270a1aea8955e79bb",
+        "id": 1760889,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "fcfdbaa2bf279c2f3e64f7f285b6c2e8debf0663",
-        "id": 1761019,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "95977e687acc3477da68170f1279f2999d73c0d9",
+            "id": 1760369,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "fcfdbaa2bf279c2f3e64f7f285b6c2e8debf0663",
+            "id": 1761019,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "ce136d4d14788ca69066360682ab630898b001bd",
@@ -3147,17 +3905,29 @@ const PerfHerderSignatures = {
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-opt": {
-        "signature": "1614bbbd62b03e02ea93241f5c122b56486d2453",
-        "id": 1760370,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "1614bbbd62b03e02ea93241f5c122b56486d2453",
+            "id": 1760370,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "284fbf4a22c968d83d7eee35045b5a3c7f5af92a",
-        "id": 1761020,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "284fbf4a22c968d83d7eee35045b5a3c7f5af92a",
+            "id": 1761020,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
       "osx-10-10-opt": {
         "signature": "092b5784927acbeafba177b7e9f8fe6aa796dacb",
@@ -3167,241 +3937,59 @@ const PerfHerderSignatures = {
       }
     }
   },
-  "debugger-metrics.summary": {
+  "summary": {
     "platforms": {
-      "linux64-opt": {
-        "signature": "04f3238439cddeb3d74b867581ba85e33205657b",
-        "id": 1882502,
+      "windows7-32-opt": {
+        "signature": "2fa549258445b035f7463afad97852e46b399a6d",
+        "id": 1760562,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "660ab0e7dcc2eaa73c6d47a1037c34621c0172ee",
-        "id": 1882517,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "debugger-metrics.all-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "dfdf0c55027fb46908b712baeb482771c001813c",
-        "id": 1882506,
+      "windows7-32-pgo": {
+        "signature": "389a5b1ef37772bad22611e4d6237fffea35c9cb",
+        "id": 1761212,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "f5eeca07629ac87a68f67b205158d05f8f274cad",
-        "id": 1882521,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "debugger-metrics.all-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "6c6936768c4105edf53aa7f5d1c8ea1ed6540689",
-        "id": 1882505,
+      "windows10-64-opt": {
+        "signature": "28c4fee1ef7d4e5d184aa628df7c94de208b7678",
+        "id": 1760887,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "5454896ffe54da65711b21f3c622c4714671123e",
-        "id": 1882520,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "debugger-metrics.debugger-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "a3a32186e330ea7b249c30af124f39220e469dea",
-        "id": 1882504,
+      "windows10-64-pgo": {
+        "signature": "2e2b666b2c9746ca9fe1184efc6f182c330e8398",
+        "id": 1761277,
         "old_signatures": [],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "958422f95f32b70c6a3690181565d081a783cc2a",
-        "id": 1882519,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "debugger-metrics.debugger-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "16687362864be0fc85c8c3c7dd17927de50b1392",
-        "id": 1882503,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "d0aa31b4a8617d5bda9bc8c5ca7bfa9a77c38c7c",
+            "id": 1761017,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "0a89f7a546734431328c27655fb17a2f79126f5d",
-        "id": 1882518,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.summary": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "cd0ad1d75f50ba898276c7ed1226abe3862d566e",
-        "id": 1788270,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.all-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "2df4c4d909dc9fda60f2bd22c0fbb25da70972d1",
-        "id": 1788274,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.all-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "475c7713d1b712eeefdcaec3ff039edd007a57ca",
-        "id": 1788273,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.inspector-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "15124dd0bee2d5faa61041c89c2d11ab3be54f7f",
-        "id": 1788272,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "inspector-metrics.inspector-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "802477185dfd6d33456c5a0adb9b54fa8f8ff342",
-        "id": 1788271,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.summary": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "2ebf3b72f445f63995e4d8775d283cdb46d99da0",
-        "id": 1882507,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-opt": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f79b6a4f1f8f53326d3056f6c8008c0ff4de0a94",
+            "id": 1760367,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       },
-      "linux64-pgo": {
-        "signature": "9df09d62b37c062dfcf6f1ac9104365234ca1b7e",
-        "id": 1882512,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.all-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "fd4f767546e07f7cc4db0690e070c04a8d47cb57",
-        "id": 1882511,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "95c7c0335712fe15de7276eb4815ed2e59c26911",
-        "id": 1882516,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.all-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "7e2b7d87725be8bf3c8d58b51366358e06f6aa11",
-        "id": 1882510,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "2b467584b4bf1a8324d0a46491bfed70bd31bab5",
-        "id": 1882515,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.netmonitor-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "dbe6313e21963fb86e800397c61c7966b913a113",
-        "id": 1882509,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "5d8fb52f8104df92a3b3c352d5dcc78c4c1296e3",
-        "id": 1882514,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "netmonitor-metrics.netmonitor-modules": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "d3184cd7586b92c51ab7392e5ec9032fd90cf45d",
-        "id": 1882508,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "d3eecfbe4a794884adaeabe3ec487b1ed40f2f8e",
-        "id": 1882513,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "total-after-gc.summary": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "ad0e53f5fe05d6d7d12d9e8d72f9efe96c796ae4",
-        "id": 1977722,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "total-after-gc.after": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "d4ec8684faaca43476b8255c65c4a6b729fce266",
-        "id": 1977724,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "total-after-gc.before": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "47d1cc41853f6cfa37db5a9c2cd7834d19ec314f",
-        "id": 1977723,
+      "osx-10-10-opt": {
+        "signature": "7cbb05567f41ef34c669c6987c808f3fc1f5ef57",
+        "id": 1760757,
         "old_signatures": [],
         "framework": 12
       }
@@ -3409,80 +3997,571 @@ const PerfHerderSignatures = {
   },
   "webconsole-metrics.summary": {
     "platforms": {
-      "linux64-opt": {
-        "signature": "461f4aa6d2559a6111e3fb81f4047d04b63dc279",
-        "id": 1881285,
-        "old_signatures": [],
+      "linux1804-64-opt": {
+        "signature": "222e51276dfb18f7210a14630f63f22a1eb2547a",
+        "id": 2245936,
+        "old_signatures": [
+          {
+            "signature": "461f4aa6d2559a6111e3fb81f4047d04b63dc279",
+            "id": 1881285,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "1ea98c07da5daf8cd5180967dbefdbb5063cd61c",
-        "id": 1881295,
-        "old_signatures": [],
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "1ea98c07da5daf8cd5180967dbefdbb5063cd61c",
+            "id": 1881295,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "netmonitor-metrics.summary": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "23a74731730967ef9842e142d2720fe3b5727e6b",
+        "id": 2245902,
+        "old_signatures": [
+          {
+            "signature": "2ebf3b72f445f63995e4d8775d283cdb46d99da0",
+            "id": 1882507,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "9df09d62b37c062dfcf6f1ac9104365234ca1b7e",
+            "id": 1882512,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "total-after-gc.after": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "964df39e66a09f8b466a426e45e4991e55280556",
+        "id": 2245901,
+        "old_signatures": [
+          {
+            "signature": "d4ec8684faaca43476b8255c65c4a6b729fce266",
+            "id": 1977724,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "netmonitor-metrics.all-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "2b2d8e5318d99a336653072ef3b1fb28b96be05e",
+        "id": 2245906,
+        "old_signatures": [
+          {
+            "signature": "fd4f767546e07f7cc4db0690e070c04a8d47cb57",
+            "id": 1882511,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "95c7c0335712fe15de7276eb4815ed2e59c26911",
+            "id": 1882516,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "debugger-metrics.all-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "70c2962e9ce70d97ba390576e167effd1fb7a072",
+        "id": 2245916,
+        "old_signatures": [
+          {
+            "signature": "dfdf0c55027fb46908b712baeb482771c001813c",
+            "id": 1882506,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "f5eeca07629ac87a68f67b205158d05f8f274cad",
+            "id": 1882521,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "webconsole-metrics.all-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "27bdae5fb0e643d280cf9ec1903af6f53bee0702",
+        "id": 2245939,
+        "old_signatures": [
+          {
+            "signature": "e9fd6c5f5547b5c456104b85e78d3c468dd6f8cf",
+            "id": 1881288,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "320871399666a591ff733ea141ac51b8c00d1854",
+            "id": 1881298,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "netmonitor-metrics.all-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "3fd12b8c6717c512741b0260316c3ea77bc0ad4c",
+        "id": 2245905,
+        "old_signatures": [
+          {
+            "signature": "7e2b7d87725be8bf3c8d58b51366358e06f6aa11",
+            "id": 1882510,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "2b467584b4bf1a8324d0a46491bfed70bd31bab5",
+            "id": 1882515,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "debugger-metrics.all-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "7863069ab91b7c48b816e7bf22ed7c16915b9201",
+        "id": 2245915,
+        "old_signatures": [
+          {
+            "signature": "6c6936768c4105edf53aa7f5d1c8ea1ed6540689",
+            "id": 1882505,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5454896ffe54da65711b21f3c622c4714671123e",
+            "id": 1882520,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "inspector-metrics.all-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "96d76f801d38b6ef688e8e1b25f1ceff7f59b6d0",
+        "id": 2245910,
+        "old_signatures": [
+          {
+            "signature": "475c7713d1b712eeefdcaec3ff039edd007a57ca",
+            "id": 1788273,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "total-after-gc.before": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "4196b19eb5450c0ab758a3800f3e90e1dba112f5",
+        "id": 2245900,
+        "old_signatures": [
+          {
+            "signature": "47d1cc41853f6cfa37db5a9c2cd7834d19ec314f",
+            "id": 1977723,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "debugger-metrics.debugger-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "95ed611c71724fff562013f724e3c108f0d9acb6",
+        "id": 2245914,
+        "old_signatures": [
+          {
+            "signature": "a3a32186e330ea7b249c30af124f39220e469dea",
+            "id": 1882504,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "958422f95f32b70c6a3690181565d081a783cc2a",
+            "id": 1882519,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "inspector-metrics.inspector-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "691729baaa3834d560a36159552f8c05d3f5a9da",
+        "id": 2245909,
+        "old_signatures": [
+          {
+            "signature": "15124dd0bee2d5faa61041c89c2d11ab3be54f7f",
+            "id": 1788272,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "inspector-metrics.inspector-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "3e9fb3353d64e210895a99f7a614f5630474e117",
+        "id": 2245908,
+        "old_signatures": [
+          {
+            "signature": "802477185dfd6d33456c5a0adb9b54fa8f8ff342",
+            "id": 1788271,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "netmonitor-metrics.netmonitor-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "39e9d6c8bd2a6bd76f0625e4badca1acccefd345",
+        "id": 2245903,
+        "old_signatures": [
+          {
+            "signature": "d3184cd7586b92c51ab7392e5ec9032fd90cf45d",
+            "id": 1882508,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "d3eecfbe4a794884adaeabe3ec487b1ed40f2f8e",
+            "id": 1882513,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "webconsole-metrics.webconsole-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "985fed5778bc450221aea4fd6e4dfc16867f6165",
+        "id": 2245938,
+        "old_signatures": [
+          {
+            "signature": "fb201e42a62fa5e3507d0f422ee912111fff18ff",
+            "id": 1881287,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "3e3c41a45c5df24fff4ff5970f23a63aa59bb2bc",
+            "id": 1881297,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "total-after-gc.summary": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "9bc8a24db151d7e78a0057d1e72dc951d6f09a63",
+        "id": 2245899,
+        "old_signatures": [
+          {
+            "signature": "ad0e53f5fe05d6d7d12d9e8d72f9efe96c796ae4",
+            "id": 1977722,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      }
+    }
+  },
+  "inspector-metrics.all-chars": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "cb1eec15065d3528b8281aac8183e8d2d06a0ca3",
+        "id": 2245911,
+        "old_signatures": [
+          {
+            "signature": "2df4c4d909dc9fda60f2bd22c0fbb25da70972d1",
+            "id": 1788274,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       }
     }
   },
   "webconsole-metrics.all-chars": {
     "platforms": {
-      "linux64-opt": {
-        "signature": "bd822038bfb99e58596afe108fabaf544d9e4bfc",
-        "id": 1881289,
-        "old_signatures": [],
+      "linux1804-64-opt": {
+        "signature": "cbee330e131fe279108cd502cec1e2ad975eb736",
+        "id": 2245940,
+        "old_signatures": [
+          {
+            "signature": "bd822038bfb99e58596afe108fabaf544d9e4bfc",
+            "id": 1881289,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "5f22ce0132cacc5da507d0f37187b9acd88aab54",
-        "id": 1881299,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5f22ce0132cacc5da507d0f37187b9acd88aab54",
+            "id": 1881299,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
-  "webconsole-metrics.all-modules": {
+  "netmonitor-metrics.netmonitor-chars": {
     "platforms": {
-      "linux64-opt": {
-        "signature": "e9fd6c5f5547b5c456104b85e78d3c468dd6f8cf",
-        "id": 1881288,
-        "old_signatures": [],
+      "linux1804-64-opt": {
+        "signature": "d704ba0d9ffb147357e0f088e6da3caddd093157",
+        "id": 2245904,
+        "old_signatures": [
+          {
+            "signature": "dbe6313e21963fb86e800397c61c7966b913a113",
+            "id": 1882509,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "320871399666a591ff733ea141ac51b8c00d1854",
-        "id": 1881298,
-        "old_signatures": [],
-        "framework": 12
-      }
-    }
-  },
-  "webconsole-metrics.webconsole-chars": {
-    "platforms": {
-      "linux64-opt": {
-        "signature": "fb201e42a62fa5e3507d0f422ee912111fff18ff",
-        "id": 1881287,
-        "old_signatures": [],
-        "framework": 12
-      },
-      "linux64-pgo": {
-        "signature": "3e3c41a45c5df24fff4ff5970f23a63aa59bb2bc",
-        "id": 1881297,
-        "old_signatures": [],
-        "framework": 12
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "5d8fb52f8104df92a3b3c352d5dcc78c4c1296e3",
+            "id": 1882514,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
       }
     }
   },
   "webconsole-metrics.webconsole-modules": {
     "platforms": {
-      "linux64-opt": {
-        "signature": "3b56b480910dc5e20d780bcd1c29ee261877910e",
-        "id": 1881286,
-        "old_signatures": [],
+      "linux1804-64-opt": {
+        "signature": "ab6aaf16df1aa0e4fea0b9fc51f832cccb06b77f",
+        "id": 2245937,
+        "old_signatures": [
+          {
+            "signature": "3b56b480910dc5e20d780bcd1c29ee261877910e",
+            "id": 1881286,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       },
-      "linux64-pgo": {
-        "signature": "b98fca31742ec8be3cfea3c67039e3787bedac67",
-        "id": 1881296,
-        "old_signatures": [],
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "b98fca31742ec8be3cfea3c67039e3787bedac67",
+            "id": 1881296,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "debugger-metrics.summary": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "d971ac851e8405d4c12d0b071361abd71815c64c",
+        "id": 2245912,
+        "old_signatures": [
+          {
+            "signature": "04f3238439cddeb3d74b867581ba85e33205657b",
+            "id": 1882502,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "660ab0e7dcc2eaa73c6d47a1037c34621c0172ee",
+            "id": 1882517,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "debugger-metrics.debugger-modules": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "f0205cdc2ed7ecba68c886e4435e0a678480f2c4",
+        "id": 2245913,
+        "old_signatures": [
+          {
+            "signature": "16687362864be0fc85c8c3c7dd17927de50b1392",
+            "id": 1882503,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
+        "framework": 12
+      },
+      "linux1804-64-pgo": {
+        "signature": null,
+        "id": null,
+        "old_signatures": [
+          {
+            "signature": "0a89f7a546734431328c27655fb17a2f79126f5d",
+            "id": 1882518,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ]
+      }
+    }
+  },
+  "inspector-metrics.summary": {
+    "platforms": {
+      "linux1804-64-opt": {
+        "signature": "fc1bec984a00eacf61f852e1c38be840a951a034",
+        "id": 2245907,
+        "old_signatures": [
+          {
+            "signature": "cd0ad1d75f50ba898276c7ed1226abe3862d566e",
+            "id": 1788270,
+            "framework": 12,
+            "before": 1575932400000
+          }
+        ],
         "framework": 12
       }
     }

--- a/perfherder/update-perfherder-signatures.html
+++ b/perfherder/update-perfherder-signatures.html
@@ -6,6 +6,7 @@
 const platforms = [
   "windows7-32",
   "windows10-64",
+  "linux1804-64",
   "linux64",
   "osx-10-10",
 ];
@@ -45,41 +46,32 @@ async function update() {
         }
         let s = final[name];
         // getCollectionName returns "pgo" or "opt"
-        let platform = t.machine_platform + "-" + getCollectionName(t.option_collection_hash);
-        if (!s.platforms[platform]) {
-          s.platforms[platform] = {
+        let build = (platform == "linux64" ? "linux1804-64" : platform) + "-" + getCollectionName(t.option_collection_hash);
+        console.log(build, name);
+        if (!s.platforms[build]) {
+          s.platforms[build] = {
             signature: null,
             id: null,
             old_signatures: []
           };
         }
 
-        // Starting August 15th 2018, DAMP runs in its own framework
-        if (framework == 12) {
-          s.platforms[platform].signature = t.signature;
-          s.platforms[platform].id = t.id;
-          s.platforms[platform].framework = framework;
-        } else {
-          // Since Feb 09 2018, now tests includes "stylo" in extra_options.
-          // But we still have to fetch the ones without "stylo" for any data before Feb 09.
-          let before;
-          if (t.extra_options.includes("stylo")) {
-            before = new Date(2018, 7, 15, 0, 0).getTime();
-          } else {
-            before = new Date(2018, 1, 9, 0, 0).getTime(); // The date when this test became obsolete
-          }
-          s.platforms[platform].old_signatures.push({
+        if (platform == "linux64") {
+          // Starting December 10th 2019, linux builds are now named linux1806 instead of linux64 (bug 1602863)
+          s.platforms[build].old_signatures.push({
             signature : t.signature,
             id: t.id,
             framework,
-            before,
+            before: new Date(2019, 11, 10, 0, 0).getTime(),
           });
+        } else {
+          s.platforms[build].signature = t.signature;
+          s.platforms[build].id = t.id;
+          s.platforms[build].framework = framework;
         }
       });
     }
   }
-  // Fetch old DAMP run, when it used to run as part of Talos
-  await fetchFramework(1);
   // Starting August 15th 2018, DAMP now runs in its own framework to be sheriffed individualy
   await fetchFramework(12);
 

--- a/tools/memory.html
+++ b/tools/memory.html
@@ -13,7 +13,7 @@
 <h4>Attaching to a tab target</h4>
 
 <h3>Allocated objects before (informative)</h4>
-<iframe src="../perfherder/?test=total-after-gc.before&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=total-after-gc.before&platform=linux1804-64-opt"></iframe>
 
 <h3>Still allocated after attach</h4>
-<iframe src="../perfherder/?test=total-after-gc.after&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=total-after-gc.after&platform=linux1804-64-opt"></iframe>

--- a/tools/module-metrics-debugger.html
+++ b/tools/module-metrics-debugger.html
@@ -11,13 +11,13 @@
 <h1>Debugger Module metrics</h1>
 
 <h4>All modules</h4>
-<iframe src="../perfherder/?test=debugger-metrics.all-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=debugger-metrics.all-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>All chars</h4>
-<iframe src="../perfherder/?test=debugger-metrics.all-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=debugger-metrics.all-chars&platform=linux1804-64-opt"></iframe>
 
 <h4>Debugger modules</h4>
-<iframe src="../perfherder/?test=debugger-metrics.debugger-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=debugger-metrics.debugger-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>Debugger chars</h4>
-<iframe src="../perfherder/?test=debugger-metrics.debugger-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=debugger-metrics.debugger-chars&platform=linux1804-64-opt"></iframe>

--- a/tools/module-metrics-inspector.html
+++ b/tools/module-metrics-inspector.html
@@ -11,13 +11,13 @@
 <h1>Inspector Module metrics</h1>
 
 <h4>All modules</h4>
-<iframe src="../perfherder/?test=inspector-metrics.all-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=inspector-metrics.all-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>All chars</h4>
-<iframe src="../perfherder/?test=inspector-metrics.all-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=inspector-metrics.all-chars&platform=linux1804-64-opt"></iframe>
 
 <h4>Inspector modules</h4>
-<iframe src="../perfherder/?test=inspector-metrics.inspector-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=inspector-metrics.inspector-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>Inspector chars</h4>
-<iframe src="../perfherder/?test=inspector-metrics.inspector-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=inspector-metrics.inspector-chars&platform=linux1804-64-opt"></iframe>

--- a/tools/module-metrics-netmonitor.html
+++ b/tools/module-metrics-netmonitor.html
@@ -11,13 +11,13 @@
 <h1>Netmonitor Module metrics</h1>
 
 <h4>All modules</h4>
-<iframe src="../perfherder/?test=netmonitor-metrics.all-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=netmonitor-metrics.all-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>All chars</h4>
-<iframe src="../perfherder/?test=netmonitor-metrics.all-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=netmonitor-metrics.all-chars&platform=linux1804-64-opt"></iframe>
 
 <h4>Netmonitor modules</h4>
-<iframe src="../perfherder/?test=netmonitor-metrics.netmonitor-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=netmonitor-metrics.netmonitor-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>Netmonitor chars</h4>
-<iframe src="../perfherder/?test=netmonitor-metrics.netmonitor-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=netmonitor-metrics.netmonitor-chars&platform=linux1804-64-opt"></iframe>

--- a/tools/module-metrics-webconsole.html
+++ b/tools/module-metrics-webconsole.html
@@ -11,13 +11,13 @@
 <h1>WebConsole Module metrics</h1>
 
 <h4>All modules</h4>
-<iframe src="../perfherder/?test=webconsole-metrics.all-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=webconsole-metrics.all-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>All chars</h4>
-<iframe src="../perfherder/?test=webconsole-metrics.all-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=webconsole-metrics.all-chars&platform=linux1804-64-opt"></iframe>
 
 <h4>WebConsole modules</h4>
-<iframe src="../perfherder/?test=webconsole-metrics.webconsole-modules&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=webconsole-metrics.webconsole-modules&platform=linux1804-64-opt"></iframe>
 
 <h4>WebConsole chars</h4>
-<iframe src="../perfherder/?test=webconsole-metrics.webconsole-chars&platform=linux64-opt"></iframe>
+<iframe src="../perfherder/?test=webconsole-metrics.webconsole-chars&platform=linux1804-64-opt"></iframe>


### PR DESCRIPTION
Due to the recent platform change, our dashboard breaks for the metrics & memory tests.
Here I simply switch from linux64 to linux1804-64. Ideally we would aggregate data from both platforms, but for now just fixing the dashboards sounds good enough.